### PR TITLE
Changelog additions and fix #6 revised as discussed before

### DIFF
--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -73,7 +73,7 @@ import java.awt.Point;
 
 public abstract class Element {
 	// Program CONSTANTS
-	public static String E_VERSION = "3.22-29";
+	public static String E_VERSION = "3.22-30";
 	public static String E_THANKS =
 	"Developed and maintained by\n"+
 	" - Robert Fisch <robert.fisch@education.lu>\n"+

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -926,7 +926,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 	 * Save method
 	 *****************************************/
 	// returns false iff a popped-up file save dialog was cancelled by the user rather than decided
-	public void saveNSD(boolean _checkChanged)
+	public boolean saveNSD(boolean _checkChanged)
 	{
 		int res = 0;	// Save decision: 0 = do save, 1 = don't save, -1 = cancelled (don't leave)
 		

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -11,7 +11,7 @@ Legend:
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 <Foo>   -->     idea AND coding done by Foo
 
-Current development version: 3.22-29 (2015.10.29)
+Current development version: 3.22-30 (2015.10.31)
 - 01: executor: fixed a bug in the repeat loop [Sylvio Tabor]
 - 02: executor: fixed a bug while interpreting the title [Benjamin Bartsch]
 - 03: export: split PNG export into multiple images [Moritz Schulze]
@@ -59,6 +59,7 @@ Current development version: 3.22-29 (2015.10.29)
 - 29: comment popup: sticky popups eliminated, no element level limit <Kay Gürtzig>
 - 29: Arranger: No longer loses track when related Structorizer reloads <Kay Gürtzig>
 - 29: Known NEW ISSUE: Closing a dependent Structorizer kills the owning Arranger!
+- 30: Closing a Structorizer and cancelling the file update question work again.
 
 Version 3.22 (2011.11.21)
 - 01: Some fixes in Executor.java & Control.java [Kay Gürtzig]


### PR DESCRIPTION
The conflicts in Diagram.saveNSD() and Mainform.create() ought to be solved in favour of the commits included here.
Maybe it's better to increase the version once more to 3.22-30.