### PR TITLE
Bugfixes #78, #85

### DIFF
--- a/src/lu/fisch/structorizer/elements/Alternative.java
+++ b/src/lu/fisch/structorizer/elements/Alternative.java
@@ -37,6 +37,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2015.10.11      Comment drawing centralized and breakpoint mechanism prepared
  *      Kay Gürtzig     2015.11.14      Bugfix #31 (= KGU#82) in method copy
  *      Kay Gürtzig     2015.12.01      Bugfix #39 (= KGU#91) in drawing methods
+ *      Kay Gürtzig     2016.01.02      Bugfix #78 (KGU#119): New method equals(Element)
  *
  ******************************************************************************************************
  *
@@ -425,7 +426,27 @@ public class Alternative extends Element {
 		return ele;
 	}
 
-    /*@Override
+	// START KGU#119 2016-01-02: Bugfix #78
+	/**
+	 * Returns true iff _another is of same class, all persistent attributes are equal, and
+	 * all substructure of _another recursively equals the substructure of this. 
+	 * @param another - the Element to be compared
+	 * @return true on recursive structural equality, false else
+	 */
+	@Override
+	public boolean equals(Element _another)
+	{
+		boolean isEqual = super.equals(_another);
+		if (isEqual)
+		{
+			isEqual = this.qTrue.equals(((Alternative)_another).qTrue) &&
+					this.qFalse.equals(((Alternative)_another).qFalse);
+		}
+		return isEqual;
+	}
+	// END KGU#119 2016-01-02
+
+	/*@Override
     public void setColor(Color _color) 
     {
         super.setColor(_color);

--- a/src/lu/fisch/structorizer/elements/Case.java
+++ b/src/lu/fisch/structorizer/elements/Case.java
@@ -37,6 +37,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2015.10.11      Comment drawing centralized and breakpoint mechanism prepared
  *      Kay Gürtzig     2015.11.14      Bugfix #31 (= KGU#82) in method copy
  *      Kay Gürtzig     2015.11.14      Bugfix #39 (= KGU#91) in method draw()
+ *      Kay Gürtzig     2016.01.02      Bugfix #78 (KGU#119): New method equals(Element)
  *
  ******************************************************************************************************
  *
@@ -63,7 +64,7 @@ public class Case extends Element
 	
     // START KGU#91 2015-12-01: Bugfix #39 - Case may NEVER EVER interchange text and comment!
 	/**
-	 * Returns the content of the text field Full stop. No swapping here!
+	 * Returns the content of the text field. Full stop. No swapping here!
 	 * @return the text StringList
 	 */
     @Override
@@ -88,7 +89,7 @@ public class Case extends Element
     public void setText(String _text)
     {
 // START KGU#91 2015-12-01: D.R.Y. - just employ setText(StringList)
-    	text.setText(_text);
+    	text.setText(_text);	// Convert to a StringList
     	this.setText(text);
     	
 //            Subqueue s = null;
@@ -593,7 +594,7 @@ public class Case extends Element
             ele.setComment(this.getComment().copy());
             ele.setColor(this.getColor());
             ((Case) ele).qs.clear();
-            for(int i=0;i<qs.size();i++)
+            for(int i=0; i < qs.size(); i++)
             {
                     Subqueue ss = (Subqueue) ((Subqueue) this.qs.get(i)).copy();
                     ss.parent=ele;
@@ -606,7 +607,26 @@ public class Case extends Element
             return ele;
     }
 
-    // START KGU#43 2015-10-12
+	// START KGU#119 2016-01-02: Bugfix #78
+	/**
+	 * Returns true iff _another is of same class, all persistent attributes are equal, and
+	 * all substructure of _another recursively equals the substructure of this. 
+	 * @param another - the Element to be compared
+	 * @return true on recursive structural equality, false else
+	 */
+	@Override
+	public boolean equals(Element _another)
+	{
+		boolean isEqual = super.equals(_another) && this.qs.size() == ((Case)_another).qs.size();
+		for(int i = 0; isEqual && i < this.qs.size(); i++)
+		{
+			isEqual = this.qs.get(i).equals(((Case)_another).qs.get(i));
+		}
+		return isEqual;
+	}
+	// END KGU#119 2016-01-02
+
+	// START KGU#43 2015-10-12
     @Override
     public void clearBreakpoints()
     {

--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -44,6 +44,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2015.12.21      Bugfix #41/#68/#69 (KGU#93): Method transformIntermediate revised
  *      Kay Gürtzig     2015.12.23      Bugfix #74 (KGU#115): Pascal operators accidently disabled
  *                                      Enh. #75 (KGU#116): Highlighting of jump keywords (orange)
+ *      Kay Gürtzig     2016.01.02      Bugfix #78 (KGU#119): New method equals(Element)
  *
  ******************************************************************************************************
  *
@@ -274,37 +275,54 @@ public abstract class Element {
 	public abstract Rect prepareDraw(Canvas _canvas);
 	public abstract void draw(Canvas _canvas, Rect _top_left);
 	public abstract Element copy();
+	
+	// START KGU#119 2016-01-02 Bugfix #78
+	/**
+	 * Returns true iff another is of same class, all persistent attributes are equal, and
+	 * all substructure of another recursively equals the substructure of this. 
+	 * @param another - the Element to be compared
+	 * @return true on recursive structural equality, false else
+	 */
+	public boolean equals(Element another)
+	{
+		boolean isEqual = this.getClass() == another.getClass();
+		if (isEqual) isEqual = this.getText().getText().equals(another.getText().getText());
+		if (isEqual) isEqual = this.getComment().getText().equals(another.getComment().getText());
+		if (isEqual) isEqual = this.getColor().equals(another.getColor());
+		return isEqual;
+	}
+	// END KGU#119 2016-01-02
 
-        // draw point
-        Point drawPoint = new Point(0,0);
+	// draw point
+	Point drawPoint = new Point(0,0);
 
-        public StringList getCollapsedText()
-        {
-            StringList sl = new StringList();
-            // START KGU#91 2015-12-01: Bugfix #39: This is for drawing, so use switch-sensitive methods
-            //if(getText().count()>0) sl.add(getText().get(0));
-            if(getText(false).count()>0) sl.add(getText(false).get(0));
-            // END KGU#91 2015-12-01
-            sl.add(COLLAPSED);
-            return sl;
-        }
-        
-        public Point getDrawPoint()
-        {
-            Element ele = this;
-            while(ele.parent!=null) ele=ele.parent;
-            return ele.drawPoint;
-        }
+	public StringList getCollapsedText()
+	{
+		StringList sl = new StringList();
+		// START KGU#91 2015-12-01: Bugfix #39: This is for drawing, so use switch-sensitive methods
+		//if(getText().count()>0) sl.add(getText().get(0));
+		if(getText(false).count()>0) sl.add(getText(false).get(0));
+		// END KGU#91 2015-12-01
+		sl.add(COLLAPSED);
+		return sl;
+	}
 
-        public void setDrawPoint(Point point)
-        {
-            Element ele = this;
-            while(ele.parent!=null) ele=ele.parent;
-            ele.drawPoint=point;
-        }
+	public Point getDrawPoint()
+	{
+		Element ele = this;
+		while(ele.parent!=null) ele=ele.parent;
+		return ele.drawPoint;
+	}
+
+	public void setDrawPoint(Point point)
+	{
+		Element ele = this;
+		while(ele.parent!=null) ele=ele.parent;
+		ele.drawPoint=point;
+	}
 
 
-        public Element()
+	public Element()
 	{
 	}
 
@@ -334,7 +352,7 @@ public abstract class Element {
 	// START KGU#91 2015-12-01: We need a way to get the true value
 	/**
 	 * Returns the content of the text field no matter if mode isSwitchedTextAndComment
-	 * is active, use getText(boolean) for a mode-sensitive effect.
+	 * is active, use getText(false) for a mode-sensitive effect.
 	 * @return the text StringList (in normal mode) the comment StringList otherwise
 	 */
 	public StringList getText()
@@ -379,7 +397,7 @@ public abstract class Element {
 	// START KGU#91 2015-12-01: We need a way to get the true value
 	/**
 	 * Returns the content of the comment field no matter if mode isSwitchedTextAndComment
-	 * is active, use getComment(boolean) for a mode-sensitive effect.
+	 * is active, use getComment(false) for a mode-sensitive effect.
 	 * @return the text StringList (in normal mode) the comment StringList otherwise
 	 */
 	public StringList getComment()

--- a/src/lu/fisch/structorizer/elements/For.java
+++ b/src/lu/fisch/structorizer/elements/For.java
@@ -40,7 +40,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2015.11.14      Bugfixes (#28 = KGU#80 and #31 = KGU#82) in Method copy
  *      Kay Gürtzig     2015.11.30      Inheritance changed: implements ILoop
  *      Kay Gürtzig     2015.12.01      Bugfix #39 (=KGU#91) -> getText(false), prepareDraw() optimised
- *      Kay Gürtzig     2015.12.08      //Temporary modification in addFullText() as workaround for bug #46
+ *      Kay Gürtzig     2016.01.02      Bugfix #78 (KGU#119): New method equals(Element)
  *
  ******************************************************************************************************
  *
@@ -392,6 +392,20 @@ public class For extends Element implements ILoop {
 		return ele;
 	}
 	
+	// START KGU#119 2016-01-02: Bugfix #78
+	/**
+	 * Returns true iff _another is of same class, all persistent attributes are equal, and
+	 * all substructure of _another recursively equals the substructure of this. 
+	 * @param another - the Element to be compared
+	 * @return true on recursive structural equality, false else
+	 */
+	@Override
+	public boolean equals(Element _another)
+	{
+		return super.equals(_another) && this.q.equals(((For)_another).q) &&
+				this.isConsistent == ((For)_another).isConsistent;
+	}
+	// END KGU#119 2016-01-02
 	
 	// START KGU#43 2015-10-12
 	@Override

--- a/src/lu/fisch/structorizer/elements/Forever.java
+++ b/src/lu/fisch/structorizer/elements/Forever.java
@@ -39,6 +39,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2015.11.30      Inheritance changed: implements ILoop
  *		Kay Gürtzig     2015.12.02      Bugfix #39 (KGU#91) -> getText(false) on drawing, constructors
  *                                      and methods setText() now ensure field text being empty
+ *      Kay Gürtzig     2016.01.02      Bugfix #78 (KGU#119): New method equals(Element)
  *
  ******************************************************************************************************
  *
@@ -308,6 +309,19 @@ public class Forever extends Element implements ILoop {
 		return ele;
 	}
 	
+	// START KGU#119 2016-01-02: Bugfix #78
+	/**
+	 * Returns true iff _another is of same class, all persistent attributes are equal, and
+	 * all substructure of _another recursively equals the substructure of this. 
+	 * @param another - the Element to be compared
+	 * @return true on recursive structural equality, false else
+	 */
+	@Override
+	public boolean equals(Element _another)
+	{
+		return super.equals(_another) && this.q.equals(((Forever)_another).q);
+	}
+	// END KGU#119 2016-01-02
 	
 	// START KGU#43 2015-10-12
 	@Override

--- a/src/lu/fisch/structorizer/elements/Parallel.java
+++ b/src/lu/fisch/structorizer/elements/Parallel.java
@@ -38,6 +38,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2015.10.16      Method clearExecutionStatus() duly overridden.
  *      Kay Gürtzig     2015.11.14      Bugfix #31 (= KGU#82) in method copy()
  *      Kay Gürtzig     2015.12.01      Bugfix #39 (= KGU#91) in draw methods (--> getText(false))
+ *      Kay Gürtzig     2016.01.02      Bugfix #78 (KGU#119): New method equals(Element)
  *
  ******************************************************************************************************
  *
@@ -498,9 +499,9 @@ public class Parallel extends Element
             ele.qs.clear();
             for(int i=0; i<qs.size(); i++)
             {
-                    Subqueue ss = (Subqueue) ((Subqueue) this.qs.get(i)).copy();
-                    ss.parent = ele;
-                    ele.qs.add(ss);
+                    Subqueue sq = (Subqueue) ((Subqueue) this.qs.get(i)).copy();
+                    sq.parent = ele;
+                    ele.qs.add(sq);
             }
     		// START KGU#82 (bug #31) 2015-11-14
     		ele.breakpoint = this.breakpoint;
@@ -508,6 +509,25 @@ public class Parallel extends Element
 
             return ele;
     }
+
+	// START KGU#119 2016-01-02: Bugfix #78
+	/**
+	 * Returns true iff _another is of same class, all persistent attributes are equal, and
+	 * all substructure of _another recursively equals the substructure of this. 
+	 * @param another - the Element to be compared
+	 * @return true on recursive structural equality, false else
+	 */
+	@Override
+	public boolean equals(Element _another)
+	{
+		boolean isEqual = super.equals(_another) && this.qs.size() == ((Parallel)_another).qs.size();
+		for (int i = 0; isEqual && i < this.qs.size(); i++)
+		{
+			isEqual = this.qs.get(i).equals(((Parallel)_another).qs.get(i));
+		}
+		return isEqual;
+	}
+	// END KGU#119 2016-01-02
 
     // START KGU 2015-10-12
     /* (non-Javadoc)

--- a/src/lu/fisch/structorizer/elements/Repeat.java
+++ b/src/lu/fisch/structorizer/elements/Repeat.java
@@ -37,6 +37,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2015.11.14      Bugfix #31 (= KGU#82) in method copy()
  *      Kay Gürtzig     2015.11.30      Inheritance changed: implements ILoop
  *      Kay Gürtzig     2015.12.01      Bugfix #39 (= KGU#91) in draw methods (--> getText(false))
+ *      Kay Gürtzig     2016.01.02      Bugfix #78 (KGU#119): New method equals(Element)
  *
  ******************************************************************************************************
  *
@@ -283,6 +284,20 @@ public class Repeat extends Element implements ILoop {
 		// END KGU#82 (bug #31) 2015-11-14
 		return ele;
 	}
+	
+	// START KGU#119 2016-01-02: Bugfix #78
+	/**
+	 * Returns true iff _another is of same class, all persistent attributes are equal, and
+	 * all substructure of _another recursively equals the substructure of this. 
+	 * @param another - the Element to be compared
+	 * @return true on recursive structural equality, false else
+	 */
+	@Override
+	public boolean equals(Element _another)
+	{
+		return super.equals(_another) && this.q.equals(((Repeat)_another).q);
+	}
+	// END KGU#119 2016-01-02
 	
     /*@Override
     public void setColor(Color _color) 

--- a/src/lu/fisch/structorizer/elements/Subqueue.java
+++ b/src/lu/fisch/structorizer/elements/Subqueue.java
@@ -38,6 +38,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2015.10.12      Comment drawing centralized and breakpoint mechanism prepared.
  *      Kay Gürtzig     2015.11.22      New and modified methods to support operations on non-empty Subqueues (KGU#87).
  *      Kay Gürtzig     2015.11.23      Inheritance extended to IElementSequence (KGU#87), children now private.
+ *      Kay Gürtzig     2016.01.02      Bugfix #78 (KGU#119): New method equals(Element)
  *
  ******************************************************************************************************
  *
@@ -328,7 +329,26 @@ public class Subqueue extends Element implements IElementSequence {
 		return ele;
 	}
         
-    // START KGU#87 2015-11-22: Re-enabled for multiple selection (selected non-empty subqueues)    
+	// START KGU#119 2016-01-02: Bugfix #78
+	/**
+	 * Returns true iff _another is of same class, all persistent attributes are equal, and
+	 * all substructure of _another recursively equals the substructure of this. 
+	 * @param another - the Element to be compared
+	 * @return true on recursive structural equality, false else
+	 */
+	@Override
+	public boolean equals(Element _another)
+	{
+		boolean isEqual = super.equals(_another) && this.children.size() == ((Subqueue)_another).getSize();
+		for (int i = 0; isEqual && i < children.size(); i++)
+		{
+			isEqual = children.get(i).equals(((Subqueue)_another).getElement(i));
+		}
+		return isEqual;
+	}
+	// END KGU#119 2016-01-02
+
+	// START KGU#87 2015-11-22: Re-enabled for multiple selection (selected non-empty subqueues)    
     @Override
     public void setColor(Color _color) 
     {

--- a/src/lu/fisch/structorizer/elements/While.java
+++ b/src/lu/fisch/structorizer/elements/While.java
@@ -38,6 +38,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2015.11.14      Bugfix #31 (= KGU#82) in method copy()
  *      Kay Gürtzig     2015.11.30      Inheritance changed: implements ILoop
  *      Kay Gürtzig     2015.12.01      Bugfix #39 (= KGU#91) in draw methods (--> getText(false))
+ *      Kay Gürtzig     2016.01.02      Bugfix #78 (KGU#119): New method equals(Element)
  *
  ******************************************************************************************************
  *
@@ -281,6 +282,20 @@ public class While extends Element implements ILoop {
 		// END KGU#82 (bug #31) 2015-11-14
 		return ele;
 	}
+	
+	// START KGU#119 2016-01-02: Bugfix #78
+	/**
+	 * Returns true iff _another is of same class, all persistent attributes are equal, and
+	 * all substructure of _another recursively equals the substructure of this. 
+	 * @param another - the Element to be compared
+	 * @return true on recursive structural equality, false else
+	 */
+	@Override
+	public boolean equals(Element _another)
+	{
+		return super.equals(_another) && this.q.equals(((While)_another).q);
+	}
+	// END KGU#119 2016-01-02
 	
     /*@Override
     public void setColor(Color _color) 

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -45,6 +45,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2015.12.02      Bugfix #39 (KGU#91)
  *      Kay Gürtzig     2015.12.04      Bugfix #40 (KGU#94): With an error on saving, the recent file was destroyed
  *      Kay Gürtzig     2015.12.16      Bugfix #63 (KGU#111): Error message on loading failure
+ *      Kay Gürtzig     2016.01.02      Bugfix #85 (KGU#120): Root changes are also subject to undoing/redoing
  *
  ******************************************************************************************************
  *
@@ -1432,7 +1433,9 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 
 				if(data.result==true)
 				{
-					if (!element.getClass().getSimpleName().equals("Root"))
+					// START KGU#120 2016-01-02: Bugfix #85 - StringList changes of Root are to be undoable, too!
+					//if (!element.getClass().getSimpleName().equals("Root"))
+					// END KGU#120 2016-01-02
 					{
 						root.addUndo();
 					}

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -11,7 +11,7 @@ Legend:
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 <Foo>   -->     idea AND coding done by Foo
 
-Current development version: 3.23-08 (2015.12.31)
+Current development version: 3.23-08 (2016.01.02)
 - 01: Bugfix #50 - added return types to signature for function export in Pascal [lhoreman]
 - 02: Bugfix #51 - stand alone input/output identifier where not converted in Pascal export [IrisLuc]
 - 03: Bugfix #48 - delay propagation to Turtleizer <Kay Gürtzig>
@@ -48,6 +48,8 @@ Current development version: 3.23-08 (2015.12.31)
 - 07: Bugfix #74: Accidently disabled Pascal operators like =, <>, and, or <Kay Gürtzig>
 - 07: Enh. #75: Highlighting of Jump element keywords leave, return, exit <Kay Gürtzig> 
 - 08: Bugfix #82: Saving of NSDs with inconsistent FOR loops <Kay Gürtzig>
+- 08: Bugfix #78: Reloading an Arranger constellation could cause duplicates [elemhsb]
+- 08: Bugfix #85: Diagram heading or comment changes now undoable <Kay Gürtzig>
 
 Version 3.23 (2015.12.04)
 - 01: executor: fixed a bug in the repeat loop [Sylvio Tabor]


### PR DESCRIPTION
On reloading Arranger constellations, exact diagram duplicates are avoided.
Diagram heading and comment changes were to be made undoable.