### PR TITLE
Several bugfixes and little enhancements (-> version 3.23-13)

### DIFF
--- a/src/lu/fisch/structorizer/arranger/Surface.java
+++ b/src/lu/fisch/structorizer/arranger/Surface.java
@@ -567,7 +567,8 @@ public class Surface extends javax.swing.JPanel implements MouseListener, MouseM
     /**
      * Places the passed-in diagram root in the drawing area if it hadn't already been
      * residing here. If a Mainform form was given, then it is registered with the root
-     * and root will automatically be pinned.
+     * (unless there is already another Mainform associated) and root will automatically
+     * be pinned.
      * @param root - a diagram to be placed here
      * @param form - the sender of the diagram if it was pushed here from a Structorizer instance
      */
@@ -590,7 +591,8 @@ public class Surface extends javax.swing.JPanel implements MouseListener, MouseM
     /**
      * Places the passed-in diagram root in the drawing area if it hadn't already been
      * residing here. If a Mainform form was given, then it is registered with the root
-     * and root will automatically be pinned.
+     * (unless there is already another Mainform associated) and root will automatically
+     * be pinned.
      * If point is given then the diaram will be place to that position, otherwise a free
      * area is looked for.
      * @param root - the root element of the diagram to be added
@@ -661,7 +663,13 @@ public class Surface extends javax.swing.JPanel implements MouseListener, MouseM
     	// END KGU#119 2016-01-02
     	if (form != null)
     	{
-    		diagram.mainform = form;
+        	// START KGU#125 2016-01-07: We allow adoption but only for orphaned diagrams
+    		//diagram.mainform = form;
+        	if (diagram.mainform == null)
+        	{
+        		diagram.mainform = form;
+        	}
+        	// END KGU#125 2016-01-07
     		root.addUpdater(this);
     	}
     	// END KGU#2 2015-11-19

--- a/src/lu/fisch/structorizer/elements/Parallel.java
+++ b/src/lu/fisch/structorizer/elements/Parallel.java
@@ -500,7 +500,7 @@ public class Parallel extends Element
     				if (_forSelection) selected = false;
     				selMe = selCh;
     			}
-    		// START KGU#121 2016-01-03: A collapsed element has no visible substructure!
+    		// START KGU#121 2016-01-03: Bugfix #87 (continued)
     		}
     		// END KGU#121 2016-01-03
 

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -64,6 +64,7 @@ package lu.fisch.structorizer.executor;
  *      Kay Gürtzig     2016.01.07      Bugfix #91 (KGU#126): Reliable execution of empty Jump elements,
  *                                      Bugfix #92 (KGU#128): Function names were replaced within string literals
  *      Kay Gürtzig     2016.01.08      Bugfix #95 (KGU#130): div operator conversion accidently dropped
+ *      Kay Gürtzig     2016.01.09      KGU#133: Quick fix to show returned arrays in a list view rather than a message box
  *
  ******************************************************************************************************
  *
@@ -686,8 +687,19 @@ public class Executor implements Runnable
 							this.returnedValue = n;
 							if (this.callers.isEmpty())
 							{
-								JOptionPane.showMessageDialog(diagram, n,
-										"Returned result", JOptionPane.INFORMATION_MESSAGE);
+								// START KGU#133 2016-01-09: Show large arrays in a listview
+								//JOptionPane.showMessageDialog(diagram, n,
+								//		"Returned result", JOptionPane.INFORMATION_MESSAGE);
+								if (n instanceof Object[] && ((Object[])n).length > 20)
+								{
+									showArray((Object[])n, "Returned result");
+								}
+								else
+								{
+									JOptionPane.showMessageDialog(diagram, n,
+											"Returned result", JOptionPane.INFORMATION_MESSAGE);
+								}
+								// END KGU#133 2016-01-09
 							}
 							// END KGU#2 (#9) 2015-11-13
 							returned = true;
@@ -712,6 +724,26 @@ public class Executor implements Runnable
 		return successful;
 		// END KGU# (#9) 2015-11-13
 	}
+	
+	// START KGU#133 2016-01-09: New method for presenting large result arrays as scrollable list
+	private void showArray(Object[] _array, String _title)
+	{
+		JDialog arrayView = new JDialog();
+		arrayView.setTitle(_title);
+		arrayView.setIconImage(IconLoader.ico004.getImage());
+		List arrayContent = new List(10);
+		for (int i = 0; i < _array.length; i++)
+		{
+			arrayContent.add(i + ":  " + prepareValueForDisplay(_array[i]));
+		}
+		arrayView.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+		arrayView.getContentPane().add(arrayContent, BorderLayout.CENTER);
+		arrayView.setSize(300, 300);
+		arrayView.setLocationRelativeTo(control);
+		arrayView.setModalityType(ModalityType.APPLICATION_MODAL);
+		arrayView.setVisible(true);
+	}
+	// END KGU#133 2016-01-09
 	
 	// START KGU#2 (#9) 2015-11-13: New method to execute a called subroutine
 	private Object executeCall(Root root, Object[] arguments)
@@ -1751,13 +1783,13 @@ public class Executor implements Runnable
 			Function f = new Function(expression);
 			if (f.isFunction())
 			{
-				System.out.println("Looking for SUBROUTINE NSD:");
-				System.out.println("--> " + f.getName() + " (" + f.paramCount() + " parameters)");
+				//System.out.println("Looking for SUBROUTINE NSD:");
+				//System.out.println("--> " + f.getName() + " (" + f.paramCount() + " parameters)");
 				Root sub = this.findSubroutineWithSignature(f.getName(), f.paramCount());
 				if (sub != null)
 				{
-					System.out.println("Matching sub-NSD found for SUBROUTINE CALL!");
-					System.out.println("--> " + varName + " <- " + sub.getMethodName() + "(" + sub.getParameterNames().getCommaText() + ")");
+					//System.out.println("Matching sub-NSD found for SUBROUTINE CALL!");
+					//System.out.println("--> " + varName + " <- " + sub.getMethodName() + "(" + sub.getParameterNames().getCommaText() + ")");
 					Object[] args = new Object[f.paramCount()];
 					for (int p = 0; p < f.paramCount(); p++)
 					{
@@ -2036,14 +2068,14 @@ public class Executor implements Runnable
 			if (result.isEmpty() && element instanceof Call)
 			{
 				// FIXME: Disable the output instructions for the release version
-				System.out.println("Looking for SUBROUTINE NSD:");
-				System.out.println("--> " + f.getName() + " (" + f.paramCount() + " parameters)");
+				//System.out.println("Looking for SUBROUTINE NSD:");
+				//System.out.println("--> " + f.getName() + " (" + f.paramCount() + " parameters)");
 				Root sub = this.findSubroutineWithSignature(f.getName(), f.paramCount());
 				if (sub != null)
 				{
 					// FIXME: Disable the output instructions for the release version
-					System.out.println("Matching sub-NSD found for SUBROUTINE CALL!");
-					System.out.println("--> " + sub.getMethodName() + "(" + sub.getParameterNames().getCommaText() + ")");
+					//System.out.println("Matching sub-NSD found for SUBROUTINE CALL!");
+					//System.out.println("--> " + sub.getMethodName() + "(" + sub.getParameterNames().getCommaText() + ")");
 					executeCall(sub, args);
 				}
 				else

--- a/src/lu/fisch/structorizer/gui/Editor.java
+++ b/src/lu/fisch/structorizer/gui/Editor.java
@@ -36,6 +36,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2015.10.12      control elements for breakpoint handling added (KGU#43). 
  *      Kay Gürtzig     2015.11.22      Adaptations for handling selected non-empty Subqueues (KGU#87)
  *      Kay Gürtzig     2016.01.04      Enh. #87: New buttons and menu items for collapsing/expanding elements
+ *      Kay Gürtzig     2016.01.11      Enh. #103: Save button disabled while Root is unchanged (KGU#137)
  *
  ******************************************************************************************************
  *
@@ -649,6 +650,11 @@ public class Editor extends JPanel implements NSDController, ComponentListener
 				}
 			}
 		}
+		
+		// START KGU#137 2016-01-11: Bugfix #103 - Reflect the "saveworthyness" of the diagram
+		// save
+		btnSave.setEnabled(diagram.getRoot().hasChanged());
+		// END KGU#137 2016-01-11
 		
 		// undo & redo
 		btnUndo.setEnabled(diagram.getRoot().canUndo());

--- a/src/lu/fisch/structorizer/gui/Mainform.java
+++ b/src/lu/fisch/structorizer/gui/Mainform.java
@@ -86,6 +86,10 @@ public class Mainform  extends JFrame implements NSDController
 	// START KGU#49/KGU#66 2015-11-14: This decides whether to exit or just to dispose when being closed
 	private boolean isStandalone = true;	// The default is to exit...
 	// END KGU#49/KGU#66 2015-11-14
+	
+	// START KGU 2016-01-10: Enhancement #101: Show version number and stand-alone status in title
+	private String titleString = "Structorizer " + Element.E_VERSION;
+	// END KGU 2016-01-10
 		
 	/******************************
  	 * Setup the Mainform
@@ -112,7 +116,11 @@ public class Mainform  extends JFrame implements NSDController
 		 * Some JFrame specific things
 		 ******************************/
 		// set window title
-		setTitle("Structorizer");
+		// START KGU 2016-01-10: Enhancement #101 - show version number and standalone status
+		//setTitle("Structorizer");
+		if (!this.isStandalone) titleString = "(" + titleString + ")";
+		setTitle(titleString);
+		// END KGU 2016-01-10
 		// set layout (OS default)
 		setLayout(null);
 		// set windows size
@@ -525,11 +533,17 @@ public class Mainform  extends JFrame implements NSDController
         	if (root != null && root.filename != null && !root.filename.isEmpty())
         	{
         		File f = new File(root.filename);
-        		this.setTitle("Structorizer - " + f.getName());
+            	// START KGU 2016-01-10: Enhancement #101 - involve version number and stand-alone status
+        		//this.setTitle("Structorizer - " + f.getName());
+        		this.setTitle(this.titleString + " - " + f.getName());
+        		// END KGU 2016-01-10
         		done = true;
         	}
         }
-        if (!done) this.setTitle("Structorizer");
+    	// START KGU 2016-01-10: Enhancement #101 - involve version number and stand-alone status
+        //if (!done) this.setTitle("Structorizer");
+        if (!done) this.setTitle(this.titleString);
+		// END KGU 2016-01-10
     }
 
     public void updateColors() 

--- a/src/lu/fisch/structorizer/gui/Menu.java
+++ b/src/lu/fisch/structorizer/gui/Menu.java
@@ -780,6 +780,11 @@ public class Menu extends JMenuBar implements NSDController
 				}
 			}
 
+			// START KGU#137 2016-01-11: Bugfix #103 - Reflect the "saveworthyness" of the diagram
+			// save
+			menuFileSave.setEnabled(diagram.getRoot().hasChanged());
+			// END KGU#137 2016-01-11
+			
 			// undo & redo
 			menuEditUndo.setEnabled(diagram.getRoot().canUndo());
 			menuEditRedo.setEnabled(diagram.getRoot().canRedo());

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -10,7 +10,7 @@ Legend:
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 <Foo>   -->     idea AND coding done by Foo
 
-Current development version: 3.23-12 (2016.01.08)
+Current development version: 3.23-13 (2016.01.13)
 - 01: Bugfix #50 - added return types to signature for function export in Pascal [lhoreman]
 - 02: Bugfix #51 - stand alone input/output identifier where not converted in Pascal export [IrisLuc]
 - 03: Bugfix #48 - delay propagation to Turtleizer <Kay Gürtzig>
@@ -58,6 +58,13 @@ Current development version: 3.23-12 (2016.01.08)
 - 11: Bugfix #96: export: variable prefix, test expressions for shell scripts <Kay Gürtzig>
 - 12: Bugfix #99: FOR loops were saved defectively, new version can load them <Kay Gürtzig>
 - 12: Arranger: Image buttons for saving and loading resized <Kay Gürtzig>
+- 13: Bugfix #50: Return type specifications were split into several lines <Kay Gürtzig>
+- 13: GUI Enh.: Scrollable display of returned arrays (at top routine level) <Kay Gürtzig>
+- 13: Enh. #101: Title string with version number and sub-thread mark [elemhsb]
+- 13: Bugfix #102: Selection wasn't cleared after deletion, undo or redo <Kay Gürtzig>
+- 13: Issue #103: Save button visibility is to depend on changed status <Kay Gürtzig>
+- 13: Bugfix #104: Code Export could provoke index range errors <Kay Gürtzig>
+- 13: Bugfix #105: Displayed lines were cut off at apostrophes in keywords <Kay Gürtzig>
 
 Version 3.23 (2015.12.04)
 - 01: executor: fixed a bug in the repeat loop [Sylvio Tabor]
@@ -71,7 +78,7 @@ Version 3.23 (2015.12.04)
 - 08: added polish translation [Jacek Dzieniewicz]
 - 09: new drawing strategy for the IF statement [David Tremain]
 - 09: new colorizing strategy for elements [David Tremain]
-- 10: visual re-enforcement for draw & drop [David Tremain]
+- 10: visual re-enforcement for drag & drop [David Tremain]
 - 11: allow to collapse / expand elements by scrolling the mouse [David Tremain]
 - 12: added preferences on how to draw IF statements [David Tremain]
 - 13: fixed "empty line" bug [David Tremain]
@@ -92,7 +99,7 @@ Version 3.23 (2015.12.04)
 - 25: added hints to speed buttons [Rens Duijsens]
 - 26: export for Basic [Jacek Dzieniewicz]
 - 26: PL: updated [Jacek Dzieniewicz]
-- 27: array variables improvements in executor <Kay Gürtzig>
+- 27: Array variable improvements in executor <Kay Gürtzig>
 - 27: updated language files (RU,DE,EN,ES) <Kay Gürtzig>
 - 28: minor change in executor for comp. with Unimozer [Bob Fisch]
 - 29: Complex changes and enhancements as described (pull-request #7) <codemanyak>

--- a/src/lu/fisch/structorizer/parsers/NSDParser.java
+++ b/src/lu/fisch/structorizer/parsers/NSDParser.java
@@ -87,7 +87,7 @@ public class NSDParser extends DefaultHandler {
 				*/
 			}
 			
-			// START KGU#134 2016-01-08: File version now activated for bugfix #99 
+			// START KGU#134 2016-01-08: File version now needed for bugfix #99 
 			String version = Element.E_VERSION;
 			if (attributes.getIndex("version") != -1) { fileVersion = attributes.getValue("version"); }
 			// So we might react to some incompatibility... 
@@ -505,7 +505,9 @@ public class NSDParser extends DefaultHandler {
 			// END KGU#111 2015-12-16
 		}
 		
-		root.hasChanged=false;
+		// START KGU#137 2016-01-11: In theory no longer needed - should have been initialized so
+		//root.hasChanged=false;
+		// END KGU#137 2016-01-11
 		
 		return root;
 	}


### PR DESCRIPTION
Bugfix #50: Return type notations were split into several lines
Executor Enh.: Scrollable display of returned arrays (at top routine level)
Enh. #101: Title string with version number and sub-thread mark
Bugfix #102: Selection wasn't cleared after deletion, undo, or redo
Issue #103: Save button visibility is to depend on change status
Bugfix #104: Code Export could provoke index range errors
Bugfix #105: Displayed lines were cut off at apostrophes in keywords