### PR TITLE
Issues #168, #169, and #171 fixed -> version 3.24-09 candidate

### DIFF
--- a/src/lu/fisch/structorizer/elements/Alternative.java
+++ b/src/lu/fisch/structorizer/elements/Alternative.java
@@ -44,6 +44,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.03.06      Enh. #77 (KGU#117): Methods for test coverage tracking added
  *      Kay Gürtzig     2016.03.07      Bugfix #122 (KGU#136): Selection was not aware of option altPadRight 
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -451,6 +452,21 @@ public class Alternative extends Element {
 	}
 	// END KGU 2015.10.09
 	
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		Element sel = selected ? this : null;
+		if (sel == null && (sel = qTrue.findSelected()) == null)
+		{
+			sel = qFalse.findSelected();
+		}
+		return sel;
+	}
+	// END KGU#183 2016-04-24
+	
 	public Element copy()
 	{
 		Alternative ele = new Alternative(this.getText().copy());
@@ -467,6 +483,9 @@ public class Alternative extends Element {
 		ele.simplyCovered = Element.E_COLLECTRUNTIMEDATA && this.simplyCovered;
 		ele.deeplyCovered = Element.E_COLLECTRUNTIMEDATA && this.deeplyCovered;
 		// END KGU#117 2016-03-07
+		// START KGU#183 2016-04-24: Issue #169
+		ele.selected = this.selected;
+		// END KGU#183 2016-04-24
 		return ele;
 	}
 	

--- a/src/lu/fisch/structorizer/elements/Call.java
+++ b/src/lu/fisch/structorizer/elements/Call.java
@@ -40,6 +40,7 @@ package lu.fisch.structorizer.elements;
  *		Kay Gürtzig     2015.01.03      Enh. #87 (KGU#122) -> getIcon()
  *		Kay Gürtzig     2015.03.01      Bugfix #97 (KGU#136) Steady selection mechanism
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -229,6 +230,9 @@ public class Call extends Instruction {
 		ele.simplyCovered = Element.E_COLLECTRUNTIMEDATA && this.simplyCovered;
 		ele.deeplyCovered = Element.E_COLLECTRUNTIMEDATA && this.deeplyCovered;
 		// END KGU#117 2016-03-07
+		// START KGU#183 2016-04-24: Issue #169
+		ele.selected = this.selected;
+		// END KGU#183 2016-04-24
 		return ele;
 	}
 

--- a/src/lu/fisch/structorizer/elements/Case.java
+++ b/src/lu/fisch/structorizer/elements/Case.java
@@ -43,7 +43,8 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.03.02      Bugfix #97 (KGU#136): Translation-neutral selection mechanism
  *      Kay Gürtzig     2016.03.06      Enh. #77 (KGU#117): Method for test coverage tracking added
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
- *      Kay Gürtzig     2016-04-01      Issue #145 (KGU#162): Comment is yet to be shown in switchText mode
+ *      Kay Gürtzig     2016.04.01      Issue #145 (KGU#162): Comment is yet to be shown in switchText mode
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -673,17 +674,32 @@ public class Case extends Element
     }
     // END KGU 2015-10-09
     
-    public void setSelected(boolean _sel)
-    {
-            selected=_sel;
-            /* Quatsch !
-            for(int i = 0;i<qs.size();i++)
-            {
-                    ((Subqueue) qs.get(i)).setSelected(_sel);
-            }
-            */
-    }
+//    public void setSelected(boolean _sel)
+//    {
+//            selected=_sel;
+//            /* Quatsch !
+//            for(int i = 0;i<qs.size();i++)
+//            {
+//                    ((Subqueue) qs.get(i)).setSelected(_sel);
+//            }
+//            */
+//    }
 
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		Element sel = selected ? this : null;
+		for (int i = 0; sel == null && i < this.qs.size(); i++)
+		{
+			sel = qs.elementAt(i).findSelected();
+		}
+		return sel;
+	}
+	// END KGU#183 2016-04-24
+	    
     public Element copy() // Problem here???
     {
             Element ele = new Case(this.getText().getText());
@@ -704,6 +720,9 @@ public class Case extends Element
     		ele.simplyCovered = Element.E_COLLECTRUNTIMEDATA && this.simplyCovered;
     		ele.deeplyCovered = Element.E_COLLECTRUNTIMEDATA && this.deeplyCovered;
     		// END KGU#117 2016-03-07
+    		// START KGU#183 2016-04-24: Issue #169
+    		ele.selected = this.selected;
+    		// END KGU#183 2016-04-24
 
             return ele;
     }

--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -58,6 +58,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.03.10      Enh. #124 (KGU#156): Counter fields for histographic tracking added
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Runtime data collection accomplished
  *      Kay Gürtzig     2016.03.26      KGU#165: New option D7Parser.ignoreCase introduced
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -147,7 +148,7 @@ import javax.swing.ImageIcon;
 
 public abstract class Element {
 	// Program CONSTANTS
-	public static String E_VERSION = "3.24-08";
+	public static String E_VERSION = "3.24-09";
 	public static String E_THANKS =
 	"Developed and maintained by\n"+
 	" - Robert Fisch <robert.fisch@education.lu>\n"+
@@ -582,7 +583,34 @@ public abstract class Element {
 	{
 		selected=_sel;
 	}
+
+	// START KGU#183 2016-04-24: Issue #169 
+	/**
+	 * Recursively searches the subtree for the currently selected Element or Element
+	 * sequence and returns it
+	 * @return selected Element (null if none was found)
+	 */
+	public abstract Element findSelected();
+	// END KGU#183 2016-04-24
 	
+	// START KGU 2016-04-24: replaces Root.checkChild(this, _ancestor)
+    /**
+     * Checks if this is a descendant of _ancestor in the tree
+     * @param _parent - Element to be verified as ancestor of _child
+     * @return true iff this is a descendant of _ancestor
+     */
+    public boolean isDescendantOf(Element _ancestor)
+    {
+            Element tmp = this.parent;
+            boolean res = false;
+            while ((tmp != null) && !(res = tmp == _ancestor))
+            {
+            	tmp = tmp.parent;
+            }
+            return res;
+    }
+    // END KGU 2016-04-24
+
 	// START KGU#143 2016-01-22: Bugfix #114 - we need a method to decide execution involvement
 	/**
 	 * Checks execution involvement.

--- a/src/lu/fisch/structorizer/elements/For.java
+++ b/src/lu/fisch/structorizer/elements/For.java
@@ -48,6 +48,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
  *      Kay Gürtzig     2016.03.20      Enh. #84/#135 (KGU#61): enum type and methods introduced/modified
  *                                      to distinguish and handle FOR-IN loops 
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -59,13 +60,10 @@ package lu.fisch.structorizer.elements;
 import java.awt.Color;
 import java.awt.FontMetrics;
 import java.awt.Point;
-import java.util.Vector;
-import java.util.regex.Matcher;
 
 import javax.swing.ImageIcon;
 
 import lu.fisch.graphics.*;
-import lu.fisch.structorizer.executor.Function;
 import lu.fisch.structorizer.gui.IconLoader;
 import lu.fisch.structorizer.parsers.D7Parser;
 import lu.fisch.utils.*;
@@ -409,12 +407,27 @@ public class For extends Element implements ILoop {
 		return selMe;
 	}
 
-	public void setSelected(boolean _sel)
-	{
-		selected=_sel;
-		//q.setSelected(_sel);
-	}
+//	public void setSelected(boolean _sel)
+//	{
+//		selected=_sel;
+//		//q.setSelected(_sel);
+//	}
 	
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		Element sel = selected ? this : null;
+		if (sel == null)
+		{
+			sel = q.findSelected();
+		}
+		return sel;
+	}
+	// END KGU#183 2016-04-24
+	    
 	public Element copy()
 	{
 		For ele = new For(this.getText().copy());
@@ -443,6 +456,9 @@ public class For extends Element implements ILoop {
         	ele.deeplyCovered = this.deeplyCovered;
         }
 		// END KGU#117 2016-03-07
+		// START KGU#183 2016-04-24: Issue #169
+		ele.selected = this.selected;
+		// END KGU#183 2016-04-24
 		return ele;
 	}
 	

--- a/src/lu/fisch/structorizer/elements/Forever.java
+++ b/src/lu/fisch/structorizer/elements/Forever.java
@@ -45,6 +45,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.03.01      Bugfix #97 (KGU#136): Translation-neutral selection
  *      Kay Gürtzig     2016.03.06      Enh. #77 (KGU#117): Method for test coverage tracking added
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -228,7 +229,7 @@ public class Forever extends Element implements ILoop {
 		canvas.drawRect(myrect);
 		
 		myrect = _top_left.copy();
-		myrect.right = myrect.left+E_PADDING;
+		myrect.right = myrect.left + E_PADDING;
 		canvas.drawRect(myrect);
 		
 		// fill shape
@@ -284,7 +285,7 @@ public class Forever extends Element implements ILoop {
 		myrect = _top_left.copy();
 		myrect.left += Element.E_PADDING-1;
 		myrect.top += headerHeight-1;
-		myrect.bottom -= E_PADDING+1;
+		myrect.bottom -= E_PADDING/*+1*/;	// KGU 2016-04-24: +1 led to line of double thickness
 		q.draw(_canvas,myrect);
 	}
 	
@@ -334,11 +335,26 @@ public class Forever extends Element implements ILoop {
 	}
 	// END KGU 2015-10-11
 	
-	public void setSelected(boolean _sel)
+//	public void setSelected(boolean _sel)
+//	{
+//		selected=_sel;
+//		//q.setSelected(_sel);
+//	}
+	
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
 	{
-		selected=_sel;
-		//q.setSelected(_sel);
+		Element sel = selected ? this : null;
+		if (sel == null)
+		{
+			sel = q.findSelected();
+		}
+		return sel;
 	}
+	// END KGU#183 2016-04-24
 	
 	public Element copy()
 	{
@@ -358,6 +374,9 @@ public class Forever extends Element implements ILoop {
         	ele.deeplyCovered = this.deeplyCovered;
         }
 		// END KGU#117 2016-03-07
+		// START KGU#183 2016-04-24: Issue #169
+		ele.selected = this.selected;
+		// END KGU#183 2016-04-24
 		return ele;
 	}
 	

--- a/src/lu/fisch/structorizer/elements/Instruction.java
+++ b/src/lu/fisch/structorizer/elements/Instruction.java
@@ -42,6 +42,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.03.01      Bugfix #97 (KGU#136): fix accomplished
  *      Kay Gürtzig     2016.03.06      Enh. #77 (KGU#117): Fields for test coverage tracking added
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -230,6 +231,16 @@ public class Instruction extends Element {
         // END KGU#124 2016-01-03
 	}
 	
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		return selected ? this : null;
+	}
+	// END KGU#183 2016-04-24
+
 	public Element copy()
 	{
 		Instruction ele = new Instruction(this.getText().copy());
@@ -245,6 +256,9 @@ public class Instruction extends Element {
         	ele.deeplyCovered = this.deeplyCovered;
         }
 		// END KGU#117 2016-03-07
+		// START KGU#183 2016-04-24: Issue #169
+		ele.selected = this.selected;
+		// END KGU#183 2016-04-24
 		return ele;
 	}
 

--- a/src/lu/fisch/structorizer/elements/Jump.java
+++ b/src/lu/fisch/structorizer/elements/Jump.java
@@ -39,6 +39,7 @@ package lu.fisch.structorizer.elements;
  *		Kay Gürtzig     2016.01.03      Enh. #87 (KGU#122) -> getIcon()
  *		Kay Gürtzig     2016.03.01      Bugfix #97 (KGU#136) Drawing/dragging/selection consolidated
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -261,6 +262,9 @@ public class Jump extends Instruction {
         	ele.deeplyCovered = this.deeplyCovered;
         }
 		// END KGU#117 2016-03-07
+		// START KGU#183 2016-04-24: Issue #169
+		ele.selected = this.selected;
+		// END KGU#183 2016-04-24
 		return ele;
 	}
 	

--- a/src/lu/fisch/structorizer/elements/Parallel.java
+++ b/src/lu/fisch/structorizer/elements/Parallel.java
@@ -46,8 +46,9 @@ package lu.fisch.structorizer.elements;
  *                                      KGU#151: nonsense removed from prepareDraw() and draw().
  *      Kay Gürtzig     2016.03.06      Enh. #77 (KGU#117): Method for test coverage tracking added
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
- *      Kay Gürtzig     2016-04-01      Issue #145 (KGU#162): Comment is yet to be shown in switchText mode
- *      Kay Gürtzig     2016-04-05      Issue #145 solution improved and setText() stabilized
+ *      Kay Gürtzig     2016.04.01      Issue #145 (KGU#162): Comment is yet to be shown in switchText mode
+ *      Kay Gürtzig     2016.04.05      Issue #145 solution improved and setText() stabilized
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -621,17 +622,32 @@ public class Parallel extends Element
     }
     // END KGU 2015-10-11
     
-    public void setSelected(boolean _sel)
-    {
-            selected=_sel;
-            /* Quatsch !
-            for(int i = 0;i<qs.size();i++)
-            {
-                    ((Subqueue) qs.get(i)).setSelected(_sel);
-            }
-            */
-    }
+//    public void setSelected(boolean _sel)
+//    {
+//            selected=_sel;
+//            /* Quatsch !
+//            for(int i = 0;i<qs.size();i++)
+//            {
+//                    ((Subqueue) qs.get(i)).setSelected(_sel);
+//            }
+//            */
+//    }
 
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		Element sel = selected ? this : null;
+		for (int i = 0; sel == null && i < this.qs.size(); i++)
+		{
+			sel = qs.elementAt(i).findSelected();
+		}
+		return sel;
+	}
+	// END KGU#183 2016-04-24
+	    
     public Element copy() // Problem here???
     {
             Parallel ele = new Parallel(this.getText().getText());
@@ -651,6 +667,9 @@ public class Parallel extends Element
     		// START KGU#117 2016-03-07: Enh. #77
     		ele.deeplyCovered = Element.E_COLLECTRUNTIMEDATA && this.deeplyCovered;
     		// END KGU#117 2016-03-07
+    		// START KGU#183 2016-04-24: Issue #169
+    		ele.selected = this.selected;
+    		// END KGU#183 2016-04-24
 
             return ele;
     }

--- a/src/lu/fisch/structorizer/elements/Repeat.java
+++ b/src/lu/fisch/structorizer/elements/Repeat.java
@@ -44,6 +44,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.03.01      Bugfix #97 (KGU#136): Translation-neutral selection
  *      Kay Gürtzig     2016.03.06      Enh. #77 (KGU#117): Method for test coverage tracking added
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -333,12 +334,27 @@ public class Repeat extends Element implements ILoop {
 	}
 	// END KGU 2015-10-11
 	
-	public void setSelected(boolean _sel)
-	{
-		selected=_sel;
-		//q.setSelected(_sel);
-	}
+//	public void setSelected(boolean _sel)
+//	{
+//		selected=_sel;
+//		//q.setSelected(_sel);
+//	}
 	
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		Element sel = selected ? this : null;
+		if (sel == null)
+		{
+			sel = q.findSelected();
+		}
+		return sel;
+	}
+	// END KGU#183 2016-04-24
+	    
 	public Element copy()
 	{
 		Element ele = new Repeat(this.getText().copy());
@@ -352,6 +368,9 @@ public class Repeat extends Element implements ILoop {
 		// START KGU#117 2016-03-07: Enh. #77
 		ele.deeplyCovered = Element.E_COLLECTRUNTIMEDATA && this.deeplyCovered;
 		// END KGU#117 2016-03-07
+		// START KGU#183 2016-04-24: Issue #169
+		ele.selected = this.selected;
+		// END KGU#183 2016-04-24
 		return ele;
 	}
 	

--- a/src/lu/fisch/structorizer/elements/Root.java
+++ b/src/lu/fisch/structorizer/elements/Root.java
@@ -66,6 +66,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016-03-29      Methods getUsedVarNames() completely rewritten.
  *      Kay Gürtzig     2016-04-05      Bugfix #154 (KGU#176) analyse_17() peeked in a wrong collection (Parallel)
  *      Kay Gürtzig     2016-04-12      Enh. #161 (KGU#179) analyse_13_16() extended (new error16_7)
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -583,29 +584,47 @@ public class Root extends Element {
     }
     // END KGU 2015-10-11
 
-    /**
-     * Checks if _child is a descendant of _parent in the tree
-     * @param _child - Element to be verified as descendant of _parent
-     * @param _parent - Element to be verified as ancestor of _child
-     * @return true iff _cild is a descendant of _parent
-     */
-    public boolean checkChild(Element _child, Element _parent)
-    {
-            Element tmp = _child;
-            boolean res = false;
-            if(tmp != null)
-            {
-                    while ((tmp.parent!=null) && (res==false))
-                    {
-                            if(tmp.parent==_parent)
-                            {
-                                    res = true;
-                            }
-                            tmp=tmp.parent;
-                    }
-            }
-            return res;
-    }
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		Element sel = selected ? this : null;
+		if (sel == null)
+		{
+			sel = children.findSelected();
+		}
+		return sel;
+	}
+	// END KGU#183 2016-04-24
+	
+	// START KGU 2016-04-24: Replaced by Element.isDescendantOf(another)
+//    /**
+//     * Checks if _child is a descendant of _parent in the tree
+//     * @param _child - Element to be verified as descendant of _parent
+//     * @param _parent - Element to be verified as ancestor of _child
+//     * @return true iff _cild is a descendant of _parent
+//     */
+//	@Deprecated
+//    public boolean checkChild(Element _child, Element _parent)
+//    {
+//            Element tmp = _child;
+//            boolean res = false;
+//            if(tmp != null)
+//            {
+//                    while ((tmp.parent!=null) && (res==false))
+//                    {
+//                            if(tmp.parent==_parent)
+//                            {
+//                                    res = true;
+//                            }
+//                            tmp=tmp.parent;
+//                    }
+//            }
+//            return res;
+//    }
+	// END KGU 2016-04-24
 
     public void removeElement(Element _ele)
     {
@@ -840,6 +859,9 @@ public class Root extends Element {
     		// START KGU#117 2016-03-07: Enh. #77
     		ele.deeplyCovered = Element.E_COLLECTRUNTIMEDATA && this.deeplyCovered;
     		// END KGU#117 2016-03-07
+    		// START KGU#183 2016-04-24: Issue #169
+    		ele.selected = this.selected;
+    		// END KGU#183 2016-04-24
             return ele;
     }
     

--- a/src/lu/fisch/structorizer/elements/Subqueue.java
+++ b/src/lu/fisch/structorizer/elements/Subqueue.java
@@ -45,6 +45,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.03.02      Bugfix #97 (KGU#136) accomplished (translation-independent selection)
  *      Kay Gürtzig     2016.03.06      Enh. #77 (KGU#117): Method for test coverage tracking added
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -373,6 +374,50 @@ public class Subqueue extends Element implements IElementSequence {
 	}
 	// END KGU 2015-10-11
 	
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		Element sel = selected ? this : null;
+		// Now look for a selected subsequence
+		if (sel == null)
+		{
+			int from = children.size(), to = -1;
+			boolean done = false;
+			for (int i = 0; !done && i < this.children.size(); i++)
+			{
+				if (children.elementAt(i).getSelected())
+				{
+					if (from > i)
+					{
+						from = i;
+					}
+					else
+					{
+						to = i;
+					}
+				}
+				else
+				{
+					done = from < i;
+				}
+			}
+			if (to >= 0)
+			{
+				sel = new lu.fisch.structorizer.gui.SelectedSequence(this, from, to);
+			}
+		}
+		// If neither this nor a subsequence is selected then look into the deep
+		for (int i = 0; sel == null && i < this.children.size(); i++)
+		{
+			sel = children.elementAt(i).findSelected();
+		}
+		return sel;
+	}
+	// END KGU#183 2016-04-24
+	    
 	public Element copy()
 	{
 		Element ele = new Subqueue();
@@ -384,6 +429,9 @@ public class Subqueue extends Element implements IElementSequence {
 		// START KGU#117 2016-03-07: Enh. #77
 		ele.deeplyCovered = Element.E_COLLECTRUNTIMEDATA && this.deeplyCovered;
 		// END KGU#117 2016-03-07
+		// START KGU#183 2016-04-24: Issue #169
+		ele.selected = this.selected;
+		// END KGU#183 2016-04-24
 		return ele;
 	}
         

--- a/src/lu/fisch/structorizer/elements/While.java
+++ b/src/lu/fisch/structorizer/elements/While.java
@@ -44,6 +44,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.03.02      Bugfix #97 (KGU#136) accomplished (translation-independent selection)
  *      Kay Gürtzig     2016.03.06      Enh. #77 (KGU#117): Method for test coverage tracking added
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -323,12 +324,27 @@ public class While extends Element implements ILoop {
 	}
 	// END KGU 2015-10-11
 	
-	public void setSelected(boolean _sel)
-	{
-		selected=_sel;
-		//q.setSelected(_sel);
-	}
+//	public void setSelected(boolean _sel)
+//	{
+//		selected=_sel;
+//		//q.setSelected(_sel);
+//	}
 	
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		Element sel = selected ? this : null;
+		if (sel == null)
+		{
+			sel = q.findSelected();
+		}
+		return sel;
+	}
+	// END KGU#183 2016-04-24
+	    
 	public Element copy()
 	{
 		Element ele = new While(this.getText().copy());
@@ -342,6 +358,9 @@ public class While extends Element implements ILoop {
 		// START KGU#117 2016-03-07: Enh. #77
 		ele.deeplyCovered = Element.E_COLLECTRUNTIMEDATA && this.deeplyCovered;
 		// END KGU#117 2016-03-07
+		// START KGU#183 2016-04-24: Issue #169
+		ele.selected = this.selected;
+		// END KGU#183 2016-04-24
 		return ele;
 	}
 	

--- a/src/lu/fisch/structorizer/gui/SelectedSequence.java
+++ b/src/lu/fisch/structorizer/gui/SelectedSequence.java
@@ -36,6 +36,8 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2015.11.23      First issue (KGU#87).
  *      Kay Gürtzig     2016.01.22      Bugfix #114 for Enh. #38 (addressing moveUp/moveDown, KGU#143 + KGU#144).
  *      Kay Gürtzig     2016.03.01/02   Bugfix #79 (KGU#136) for reliable selection.
+ *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation
+ *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *
  ******************************************************************************************************
  *
@@ -147,9 +149,9 @@ public class SelectedSequence extends Element implements IElementSequence {
 	 */
 	@Override
 	public Rect prepareDraw(Canvas _canvas) {
-		// START KGU#136 2016-01-03: Bugfix #97
+		// START KGU#136 2016-03-01: Bugfix #97
 		if (this.isRectUpToDate) return rect0;
-		// END KGU#136 2016-01-03
+		// END KGU#136 2016-03-01
 		
 		rect0.left = rect0.right = rect0.top = rect0.bottom = 0;
 		Rect subrect = new Rect(0, 0, 0, 0);
@@ -461,7 +463,7 @@ public class SelectedSequence extends Element implements IElementSequence {
 	public void setSelected(boolean _sel)
 	{
 		//System.out.println(this + ".setSelected(" + _sel + ")");
-		selected=_sel;
+		selected = _sel;
 		for (int i = firstIndex; i <= lastIndex; i++)
 		{
 			// This must not be recursive!
@@ -469,6 +471,17 @@ public class SelectedSequence extends Element implements IElementSequence {
 		}
 	}
 
+	// START KGU#183 2016-04-24: Issue #169 
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#findSelected()
+	 */
+	public Element findSelected()
+	{
+		// Shouldn't it always return this - being a SELECTEDSequence?
+		return selected ? this : null;
+	}
+	// END KGU#183 2016-04-24
+	    
 	// START KGU#123 2016-01-03: We need a collective collapsing/expansion now
 	@Override
     public void setCollapsed(boolean collapsed) {
@@ -502,5 +515,24 @@ public class SelectedSequence extends Element implements IElementSequence {
 		}
 	}
 	// END KGU#43 2016-01-22
+
+	// START KGU#156 2016-03-11: Enh. #124
+	/* (non-Javadoc)
+	 * @see lu.fisch.structorizer.elements.Element#getExecStepCount(boolean)
+	 */
+	public int getExecStepCount(boolean _combined)
+	{
+		this.execStepCount = ((Subqueue)parent).getExecStepCount(false);
+		if (_combined && this.getSize() > 0)
+		{
+			this.execSubCount = 0;
+			for (int i = 0; i < this.getSize(); i++)
+			{
+				this.execSubCount += this.getElement(i).getExecStepCount(true);
+			}
+		}
+		return super.getExecStepCount(_combined);
+	}
+	// END KGU#156 2016-03-12
 
 }

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -9,7 +9,7 @@ Legend:
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 <Foo>   -->     idea AND coding done by Foo
 
-Current development version: 3.24-08 (2016.04.20)
+Current development version: 3.24-09 (2016.04.24)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]
 - 01: Enh. #124: Generalized runtime data visualisation <Kay Gürtzig>
 - 01: Arranger now adopts current directory from first arranged diagram <Kay Gürtzig>
@@ -43,6 +43,9 @@ Current development version: 3.24-08 (2016.04.20)
 - 07: Enh. #158: Diagram copy and paste among Structorizers and Arrangers [Rolf Schmidt]
 - 08: Issue #164: On element deletion the next element should be selected [Rolf Schmidt]
 - 08: Bugfix #165: Proper unselection on clicking outside the diagram <Kay Gürtzig>
+- 09: Issue #168: Cutting an element is to pass the selection too (cf. #164) [Rolf Schmidt]
+- 09: Issue #169: Selection ensured on start, loading an NSD, undo, redo [Rolf Schmidt]
+- 09: Bugfix #171: Twos flaws in enh. #158 mended <Kay Gürtzig>
 
 Version: 3.24 (2016.03.14)
 - 01: Bugfix #50 - added return types to signature for function export in Pascal [lhoreman]


### PR DESCRIPTION
Issue #168: Cutting an element is to pass the selection too (cf. #164)
Issue #169: Selection ensured on start, loading an NSD, undo, redo
Bugfix #171: Twos flaws in enhancement #158 item 1 mended