### PR TITLE
Bugfix3.24 providing fixes for #30, #137, #169, #173, #174 (version 3.24-10)

### DIFF
--- a/src/lu/fisch/graphics/Canvas.java
+++ b/src/lu/fisch/graphics/Canvas.java
@@ -49,7 +49,6 @@ import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.RenderingHints;
 import java.awt.geom.Rectangle2D;
-import lu.fisch.structorizer.elements.Element;
 
 
 import lu.fisch.utils.*;

--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -148,7 +148,7 @@ import javax.swing.ImageIcon;
 
 public abstract class Element {
 	// Program CONSTANTS
-	public static String E_VERSION = "3.24-09";
+	public static String E_VERSION = "3.24-10";
 	public static String E_THANKS =
 	"Developed and maintained by\n"+
 	" - Robert Fisch <robert.fisch@education.lu>\n"+

--- a/src/lu/fisch/structorizer/executor/OutputConsole.java
+++ b/src/lu/fisch/structorizer/executor/OutputConsole.java
@@ -34,6 +34,7 @@ package lu.fisch.structorizer.executor;
  *      ------			----			-----------
  *      Kay Gürtzig     2016.04.08      First Issue (implementing enhancement request #137)
  *      Kay Gürtzig     2016.04.12      Functionality accomplished
+ *      Kay Gürtzig     2016-04-25      Scrolling to last line ensured
  *
  ******************************************************************************************************
  *
@@ -43,6 +44,7 @@ package lu.fisch.structorizer.executor;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Rectangle;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -101,6 +103,11 @@ public class OutputConsole extends JFrame {
     public void write(String _text)
     {
     	this.textArea.append(_text);
+    	// Scroll to end (if there is an easier way, I just didn't find it).
+    	Rectangle rect = this.textArea.getBounds();
+    	rect.y = rect.height - 1;
+    	rect.height = 1;
+    	this.textArea.scrollRectToVisible(rect);
     }
 
     /**
@@ -113,10 +120,15 @@ public class OutputConsole extends JFrame {
     public void write(String _text, Color _colour)
     {
     	// TODO: In order to be able to format something we must use a Document
-    	Color oldColour = this.textArea.getForeground();
-    	this.textArea.setForeground(_colour);
+    	//Color oldColour = this.textArea.getForeground();
+    	//this.textArea.setForeground(_colour);
     	this.textArea.append(_text);
-    	this.textArea.setForeground(oldColour);
+    	//this.textArea.setForeground(oldColour);
+    	// Scroll to end (if there is an easier way, I just didn't find it).
+    	Rectangle rect = this.textArea.getBounds();
+    	rect.y = rect.height - 1;
+    	rect.height = 1;
+    	this.textArea.scrollRectToVisible(rect);
     }
 
     /**

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -64,6 +64,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016-04-23      Issue #168 (no selection heir on cut) and #169 (no selection on start/undo/redo)
  *      Kay Gürtzig     2016-04-24      Bugfixes for issue #158 (KGU#177): Leaving the body of Parallel, Forever etc. downwards,
  *                                      button state update was missing.
+ *      Kay Gürtzig     2016-04-24      Issue #169 accomplished: selection on start / after export
  *
  ******************************************************************************************************
  *
@@ -333,6 +334,11 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		lblPop.setPreferredSize(new Dimension(30,12));
 		jp.add(lblPop);
 		pop.add(jp);
+		
+		// START KGU#182 2016-04-24: Issue #169
+		selected = root;
+		root.setSelected(true);
+		// END KGU#182 2016-04-24
 	}
 
 	public void hideComments()
@@ -2027,7 +2033,10 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 	 *****************************************/
 	public void exportPNGmulti()
 	{
-
+		// START KGU#183 2016-04-24: Issue #169 - retain old selection
+		Element wasSelected = selected;
+		// END KGU#183 2016-04-24
+		
 		// START KGU#41 2015-10-11
 		//root.selectElementByCoord(-1,-1);	// Unselect all elements
 		//redraw();
@@ -2145,23 +2154,35 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 				}
 			}
 		}
+		// START KGU#183 2016-04-24: Issue #169 - restore old selection
+		selected = wasSelected;
+		if (selected != null)
+		{
+			selected.setSelected(true);
+		}
+		redraw();
+		// END KGU#183 2016-04-24
 	}
         
 	public void exportPNG()
 	{
-    	// START KGU#41 2015-10-11
-    	//root.selectElementByCoord(-1,-1);	// Unselect all elements
-    	//redraw();
-    	unselectAll();
-    	// END KGU#41 2015-10-11
+		// START KGU#183 2016-04-24: Issue #169 - retain old selection
+		Element wasSelected = selected;
+		// END KGU#183 2016-04-24
+
+		// START KGU#41 2015-10-11
+		//root.selectElementByCoord(-1,-1);	// Unselect all elements
+		//redraw();
+		unselectAll();
+		// END KGU#41 2015-10-11
 
 		JFileChooser dlgSave = new JFileChooser("Export diagram as PNG ...");
 		// set directory
 		if (lastExportDir!=null)
-                {
-                    dlgSave.setCurrentDirectory(lastExportDir);
-                }
-                else if(root.getFile()!=null)
+		{
+			dlgSave.setCurrentDirectory(lastExportDir);
+		}
+		else if(root.getFile()!=null)
 		{
 			dlgSave.setCurrentDirectory(root.getFile());
 		}
@@ -2189,7 +2210,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		int result = dlgSave.showSaveDialog(NSDControl.getFrame());
 		if (result == JFileChooser.APPROVE_OPTION)
 		{
-                    lastExportDir=dlgSave.getSelectedFile().getParentFile();
+			lastExportDir=dlgSave.getSelectedFile().getParentFile();
 			String filename=dlgSave.getSelectedFile().getAbsoluteFile().toString();
 			if(!filename.substring(filename.length()-4, filename.length()).toLowerCase().equals(".png"))
 			{
@@ -2197,37 +2218,49 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 			}
 
 			File file = new File(filename);
-                        boolean writeDown = true;
+			boolean writeDown = true;
 
-                        if(file.exists())
+			if(file.exists())
 			{
-                            int response = JOptionPane.showConfirmDialog (null,
-                                            "Overwrite existing file?","Confirm Overwrite",
-                                            JOptionPane.YES_NO_OPTION,
-                                            JOptionPane.QUESTION_MESSAGE);
-                            if (response == JOptionPane.NO_OPTION)
-                            {
-				writeDown=false;
-                            }
-                        }
-                        if(writeDown==true)
-                        {
-                            BufferedImage bi = new BufferedImage(root.width+1,root.height+1,BufferedImage.TYPE_4BYTE_ABGR);
-                            printAll(bi.getGraphics());
-                            try
-                            {
-                                    ImageIO.write(bi, "png", file);
-                            }
-                            catch(Exception e)
-                            {
-                                    JOptionPane.showOptionDialog(this,"Error while saving the image!","Error",JOptionPane.OK_OPTION,JOptionPane.ERROR_MESSAGE,null,null,null);
-                            }
-                        }
+				int response = JOptionPane.showConfirmDialog (null,
+						"Overwrite existing file?","Confirm Overwrite",
+						JOptionPane.YES_NO_OPTION,
+						JOptionPane.QUESTION_MESSAGE);
+				if (response == JOptionPane.NO_OPTION)
+				{
+					writeDown=false;
+				}
+			}
+			if(writeDown==true)
+			{
+				BufferedImage bi = new BufferedImage(root.width+1,root.height+1,BufferedImage.TYPE_4BYTE_ABGR);
+				printAll(bi.getGraphics());
+				try
+				{
+					ImageIO.write(bi, "png", file);
+				}
+				catch(Exception e)
+				{
+					JOptionPane.showOptionDialog(this,"Error while saving the image!","Error",JOptionPane.OK_OPTION,JOptionPane.ERROR_MESSAGE,null,null,null);
+				}
+			}
 		}
+		// START KGU#183 2016-04-24: Issue #169 - restore old selection
+		selected = wasSelected;
+		if (selected != null)
+		{
+			selected.setSelected(true);
+		}
+		redraw();
+		// END KGU#183 2016-04-24
 	}
 
 	public void exportEMF()
 	{
+		// START KGU#183 2016-04-24: Issue #169 - retain old selection
+		Element wasSelected = selected;
+		// END KGU#183 2016-04-24
+		
 		// START KGU#41 2015-10-11
 		//root.selectElementByCoord(-1,-1);	// Unselect all elements
 		//redraw();
@@ -2309,23 +2342,35 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 				}
 			}
 		}
+		// START KGU#183 2016-04-24: Issue #169 - restor old selection
+		selected = wasSelected;
+		if (selected != null)
+		{
+			selected.setSelected(true);
+		}
+		redraw();
+		// END KGU#183 2016-04-24
 	}
 
 	public void exportSVG() // does not work!!
 	{
-    	// START KGU#41 2015-10-11
-    	//root.selectElementByCoord(-1,-1);	// Unselect all elements
-    	//redraw();
-    	unselectAll();
-    	// END KGU#41 2015-10-11
+		// START KGU#183 2016-04-24: Issue #169 - retain old selection
+		Element wasSelected = selected;
+		// END KGU#183 2016-04-24
+		
+		// START KGU#41 2015-10-11
+		//root.selectElementByCoord(-1,-1);	// Unselect all elements
+		//redraw();
+		unselectAll();
+		// END KGU#41 2015-10-11
 
 		JFileChooser dlgSave = new JFileChooser("Export diagram as SVG ...");
 		// set directory
 		if (lastExportDir!=null)
-                {
-                    dlgSave.setCurrentDirectory(lastExportDir);
-                }
-                else if(root.getFile()!=null)
+		{
+			dlgSave.setCurrentDirectory(lastExportDir);
+		}
+		else if(root.getFile()!=null)
 		{
 			dlgSave.setCurrentDirectory(root.getFile());
 		}
@@ -2353,7 +2398,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		int result = dlgSave.showSaveDialog(NSDControl.getFrame());
 		if (result == JFileChooser.APPROVE_OPTION)
 		{
-                    lastExportDir=dlgSave.getSelectedFile().getParentFile();
+			lastExportDir=dlgSave.getSelectedFile().getParentFile();
 			String filename=dlgSave.getSelectedFile().getAbsoluteFile().toString();
 			if(!filename.substring(filename.length()-4, filename.length()).toLowerCase().equals(".svg"))
 			{
@@ -2361,81 +2406,89 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 			}
 
 			File file = new File(filename);
-                        boolean writeDown = true;
+			boolean writeDown = true;
 
-                        if(file.exists())
+			if(file.exists())
 			{
-                            int response = JOptionPane.showConfirmDialog (null,
-                                            "Overwrite existing file?","Confirm Overwrite",
-                                            JOptionPane.YES_NO_OPTION,
-                                            JOptionPane.QUESTION_MESSAGE);
-                            if (response == JOptionPane.NO_OPTION)
-                            {
-				writeDown=false;
-                            }
-                        }
-                        if(writeDown==true)
-                        {
-                            try
-                            {
-                                    SVGGraphics2D svg = new SVGGraphics2D(new FileOutputStream(filename),new Dimension(root.width+12, root.height+12)) ;
-                                    svg.startExport();
-                                    lu.fisch.graphics.Canvas c = new lu.fisch.graphics.Canvas(svg);
-                                    lu.fisch.graphics.Rect myrect = root.prepareDraw(c);
-                                    myrect.left+=6;
-                                    myrect.top+=6;
-                                    root.draw(c,myrect);
-                                    svg.endExport();
-                                    
-                                    // re-read the file ...
-                                    StringBuffer buffer = new StringBuffer();
-                                    InputStreamReader isr = new InputStreamReader(new FileInputStream(filename));
-                                    Reader in = new BufferedReader(isr);
-                                    int ch;
-                                    while ((ch = in.read()) > -1)
-                                    {
-                                        buffer.append((char)ch);
-                                    }
-                                    // START KGU 2015-12-04
-                                    in.close();
-                                    // END KGU 2015-12-04
+				int response = JOptionPane.showConfirmDialog (null,
+						"Overwrite existing file?","Confirm Overwrite",
+						JOptionPane.YES_NO_OPTION,
+						JOptionPane.QUESTION_MESSAGE);
+				if (response == JOptionPane.NO_OPTION)
+				{
+					writeDown=false;
+				}
+			}
+			if(writeDown==true)
+			{
+				try
+				{
+					SVGGraphics2D svg = new SVGGraphics2D(new FileOutputStream(filename),new Dimension(root.width+12, root.height+12)) ;
+					svg.startExport();
+					lu.fisch.graphics.Canvas c = new lu.fisch.graphics.Canvas(svg);
+					lu.fisch.graphics.Rect myrect = root.prepareDraw(c);
+					myrect.left+=6;
+					myrect.top+=6;
+					root.draw(c,myrect);
+					svg.endExport();
 
-                                    // ... and encode it UTF-8
-                                    FileOutputStream fos = new FileOutputStream(filename);
-                                    Writer out = new OutputStreamWriter(fos, "UTF-8");
-                                    out.write(buffer.toString());
-                                    out.close();
-                                    
-                            }
-                            catch (Exception e)
-                            {
-                                    e.printStackTrace();
-                            }
-                       }
+					// re-read the file ...
+					StringBuffer buffer = new StringBuffer();
+					InputStreamReader isr = new InputStreamReader(new FileInputStream(filename));
+					Reader in = new BufferedReader(isr);
+					int ch;
+					while ((ch = in.read()) > -1)
+					{
+						buffer.append((char)ch);
+					}
+					// START KGU 2015-12-04
+					in.close();
+					// END KGU 2015-12-04
+
+					// ... and encode it UTF-8
+					FileOutputStream fos = new FileOutputStream(filename);
+					Writer out = new OutputStreamWriter(fos, "UTF-8");
+					out.write(buffer.toString());
+					out.close();
+
+				}
+				catch (Exception e)
+				{
+					e.printStackTrace();
+				}
+			}
 		}
 
-    	// START KGU 2015-10-11
-    	//root.selectElementByCoord(-1,-1);	// Unselect all elements
-    	//redraw();
-    	unselectAll();
-    	// END KGU 2015-10-11
+		// START KGU#183 2016-04-24: Issue #169 - restore old selection
+		//unselectAll();
+		selected = wasSelected;
+		if (selected != null)
+		{
+			selected.setSelected(true);
+		}
+		redraw();
+		// END KGU#183 2016-04-24
 	}
 
 	public void exportSWF()
 	{
-    	// START KGU 2015-10-11
-    	//root.selectElementByCoord(-1,-1);	// Unselect all elements
-    	//redraw();
-    	unselectAll();
-    	// END KGU 2015-10-11
+		// START KGU#183 2016-04-24: Issue #169 - retain old selection
+		Element wasSelected = selected;
+		// END KGU#183 2016-04-24
+
+		// START KGU 2015-10-11
+		//root.selectElementByCoord(-1,-1);	// Unselect all elements
+		//redraw();
+		unselectAll();
+		// END KGU 2015-10-11
 
 		JFileChooser dlgSave = new JFileChooser("Export diagram as SWF ...");
 		// set directory
 		if (lastExportDir!=null)
-                {
-                    dlgSave.setCurrentDirectory(lastExportDir);
-                }
-                else if(root.getFile()!=null)
+		{
+			dlgSave.setCurrentDirectory(lastExportDir);
+		}
+		else if(root.getFile()!=null)
 		{
 			dlgSave.setCurrentDirectory(root.getFile());
 		}
@@ -2463,7 +2516,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		int result = dlgSave.showSaveDialog(NSDControl.getFrame());
 		if (result == JFileChooser.APPROVE_OPTION)
 		{
-                    lastExportDir=dlgSave.getSelectedFile().getParentFile();
+			lastExportDir=dlgSave.getSelectedFile().getParentFile();
 			String filename=dlgSave.getSelectedFile().getAbsoluteFile().toString();
 			if(!filename.substring(filename.length()-4, filename.length()).toLowerCase().equals(".swf"))
 			{
@@ -2471,56 +2524,68 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 			}
 
 			File file = new File(filename);
-                        boolean writeDown = true;
+			boolean writeDown = true;
 
-                        if(file.exists())
+			if(file.exists())
 			{
-                            int response = JOptionPane.showConfirmDialog (null,
-                                            "Overwrite existing file?","Confirm Overwrite",
-                                            JOptionPane.YES_NO_OPTION,
-                                            JOptionPane.QUESTION_MESSAGE);
-                            if (response == JOptionPane.NO_OPTION)
-                            {
-				writeDown=false;
-                            }
-                        }
-                        if(writeDown==true)
-                        {
-                            try
-                            {
-                                    SWFGraphics2D svg = new SWFGraphics2D(new FileOutputStream(filename),new Dimension(root.width+12, root.height+12)) ;
+				int response = JOptionPane.showConfirmDialog (null,
+						"Overwrite existing file?","Confirm Overwrite",
+						JOptionPane.YES_NO_OPTION,
+						JOptionPane.QUESTION_MESSAGE);
+				if (response == JOptionPane.NO_OPTION)
+				{
+					writeDown=false;
+				}
+			}
+			if(writeDown==true)
+			{
+				try
+				{
+					SWFGraphics2D svg = new SWFGraphics2D(new FileOutputStream(filename),new Dimension(root.width+12, root.height+12)) ;
 
-                                    svg.startExport();
-                                    lu.fisch.graphics.Canvas c = new lu.fisch.graphics.Canvas(svg);
-                                    lu.fisch.graphics.Rect myrect = root.prepareDraw(c);
-                                    myrect.left+=6;
-                                    myrect.top+=6;
-                                    root.draw(c,myrect);
-                                    svg.endExport();
-                            }
-                            catch (Exception e)
-                            {
-                                    e.printStackTrace();
-                            }
-                       }
+					svg.startExport();
+					lu.fisch.graphics.Canvas c = new lu.fisch.graphics.Canvas(svg);
+					lu.fisch.graphics.Rect myrect = root.prepareDraw(c);
+					myrect.left+=6;
+					myrect.top+=6;
+					root.draw(c,myrect);
+					svg.endExport();
+				}
+				catch (Exception e)
+				{
+					e.printStackTrace();
+				}
+			}
 		}
+		// START KGU#183 2016-04-24: Issue #169 - restore old selection
+		selected = wasSelected;
+		if (selected != null)
+		{
+			selected.setSelected(true);
+		}
+		redraw();
+		// END KGU#183 2016-04-24
 	}
 
 	public void exportPDF()
 	{
-    	// START KGU 2015-10-11
-    	//root.selectElementByCoord(-1,-1);	// Unselect all elements
-    	//redraw();
-    	unselectAll();
-    	// END KGU 2015-10-11
+		// START KGU#183 2016-04-24: Issue #169 - retain old selection
+		Element wasSelected = selected;
+		// END KGU#183 2016-04-24
+
+		// START KGU 2015-10-11
+		//root.selectElementByCoord(-1,-1);	// Unselect all elements
+		//redraw();
+		unselectAll();
+		// END KGU 2015-10-11
 
 		JFileChooser dlgSave = new JFileChooser("Export diagram as PDF ...");
 		// set directory
 		if (lastExportDir!=null)
-                {
-                    dlgSave.setCurrentDirectory(lastExportDir);
-                }
-                else if(root.getFile()!=null)
+		{
+			dlgSave.setCurrentDirectory(lastExportDir);
+		}
+		else if(root.getFile()!=null)
 		{
 			dlgSave.setCurrentDirectory(root.getFile());
 		}
@@ -2548,7 +2613,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		int result = dlgSave.showSaveDialog(NSDControl.getFrame());
 		if (result == JFileChooser.APPROVE_OPTION)
 		{
-                    lastExportDir=dlgSave.getSelectedFile().getParentFile();
+			lastExportDir=dlgSave.getSelectedFile().getParentFile();
 			String filename=dlgSave.getSelectedFile().getAbsoluteFile().toString();
 			if(!filename.substring(filename.length()-4, filename.length()).toLowerCase().equals(".pdf"))
 			{
@@ -2556,39 +2621,47 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 			}
 
 			File file = new File(filename);
-                        boolean writeDown = true;
+			boolean writeDown = true;
 
-                        if(file.exists())
+			if(file.exists())
 			{
-                            int response = JOptionPane.showConfirmDialog (null,
-                                            "Overwrite existing file?","Confirm Overwrite",
-                                            JOptionPane.YES_NO_OPTION,
-                                            JOptionPane.QUESTION_MESSAGE);
-                            if (response == JOptionPane.NO_OPTION)
-                            {
-				writeDown=false;
-                            }
-                        }
-                        if(writeDown==true)
-                        {
-                            try
-                            {
-                                    PDFGraphics2D svg = new PDFGraphics2D(new FileOutputStream(filename),new Dimension(root.width+12, root.height+12)) ;
+				int response = JOptionPane.showConfirmDialog (null,
+						"Overwrite existing file?","Confirm Overwrite",
+						JOptionPane.YES_NO_OPTION,
+						JOptionPane.QUESTION_MESSAGE);
+				if (response == JOptionPane.NO_OPTION)
+				{
+					writeDown=false;
+				}
+			}
+			if(writeDown==true)
+			{
+				try
+				{
+					PDFGraphics2D svg = new PDFGraphics2D(new FileOutputStream(filename),new Dimension(root.width+12, root.height+12)) ;
 
-                                    svg.startExport();
-                                    lu.fisch.graphics.Canvas c = new lu.fisch.graphics.Canvas(svg);
-                                    lu.fisch.graphics.Rect myrect = root.prepareDraw(c);
-                                        myrect.left+=6;
-                                        myrect.top+=6;
-                                    root.draw(c,myrect);
-                                    svg.endExport();
-                            }
-                            catch (Exception e)
-                            {
-                                    e.printStackTrace();
-                            }
-                        }
+					svg.startExport();
+					lu.fisch.graphics.Canvas c = new lu.fisch.graphics.Canvas(svg);
+					lu.fisch.graphics.Rect myrect = root.prepareDraw(c);
+					myrect.left+=6;
+					myrect.top+=6;
+					root.draw(c,myrect);
+					svg.endExport();
+				}
+				catch (Exception e)
+				{
+					e.printStackTrace();
+				}
+			}
 		}
+		// START KGU#183 2016-04-24: Issue #169 - restore old selection
+		selected = wasSelected;
+		if (selected != null)
+		{
+			selected.setSelected(true);
+		}
+		redraw();
+		// END KGU#183 2016-04-24
 	}
 
 
@@ -2634,6 +2707,10 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 				boolean hil = root.hightlightVars;
 				root = rootNew;
 				root.hightlightVars = hil;
+				// START KGU#183 2016-04-24: Enh. #169
+				selected = root;
+				selected.setSelected(true);
+				// END KGU#183 2016-04-24
 			}
 			else
 			{
@@ -3383,13 +3460,17 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
      *****************************************/
 	public void copyToClipboardPNG()
 	{
-    	// START KGU 2015-10-11
-    	//root.selectElementByCoord(-1,-1);	// Unselect all elements
-    	//redraw();
-    	unselectAll();
-    	// END KGU 2015-10-11
+		// START KGU#183 2016-04-24: Issue #169 - retain old selection
+		Element wasSelected = selected;
+		// END KGU#183 2016-04-24
 
-                Clipboard systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+		// START KGU 2015-10-11
+		//root.selectElementByCoord(-1,-1);	// Unselect all elements
+		//redraw();
+		unselectAll();
+		// END KGU 2015-10-11
+
+		Clipboard systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 		//DataFlavor pngFlavor = new DataFlavor("image/png","Portable Network Graphics");
 
 		// get diagram
@@ -3399,17 +3480,30 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		// put image to clipboard
 		ImageSelection imageSelection = new ImageSelection(image);
 		systemClipboard.setContents(imageSelection, null);
+
+		// START KGU#183 2016-04-24: Issue #169 - restore old selection
+		selected = wasSelected;
+		if (selected != null)
+		{
+			selected.setSelected(true);
+		}
+		redraw();
+		// END KGU#183 2016-04-24
 	}
 
 	public void copyToClipboardEMF()
 	{
-    	// START KGU 2015-10-11
-    	//root.selectElementByCoord(-1,-1);	// Unselect all elements
-    	//redraw();
-    	unselectAll();
-    	// END KGU 2015-10-11
+		// START KGU#183 2016-04-24: Issue #169 - retain old selection
+		Element wasSelected = selected;
+		// END KGU#183 2016-04-24
 
-                Clipboard systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+		// START KGU 2015-10-11
+		//root.selectElementByCoord(-1,-1);	// Unselect all elements
+		//redraw();
+		unselectAll();
+		// END KGU 2015-10-11
+
+		Clipboard systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 
 		try
 		{
@@ -3429,6 +3523,15 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		{
 			e.printStackTrace();
 		}
+
+		// START KGU#183 2016-04-24: Issue #169 - restore old selection
+		selected = wasSelected;
+		if (selected != null)
+		{
+			selected.setSelected(true);
+		}
+		redraw();
+		// END KGU#183 2016-04-24
 	}
 
     @Override

--- a/src/lu/fisch/structorizer/gui/LangDialog.java
+++ b/src/lu/fisch/structorizer/gui/LangDialog.java
@@ -43,7 +43,7 @@ package lu.fisch.structorizer.gui;
  ******************************************************************************************************///
 
 import java.awt.*;
-
+import java.awt.event.KeyEvent;
 import java.io.*;
 import java.lang.reflect.*;
 
@@ -189,8 +189,19 @@ public class LangDialog extends JDialog
 								Method method = fieldClass.getMethod("setTitleAt",new Class [] {int.class,String.class});
 								method.invoke(field.get(_com),new Object [] {Integer.valueOf(pieces.get(3)),parts.get(1)});
 							}
+							// START KGU#183 2016-04-24: Enh. #173 - new support
+							else if (piece2.equals("mnemonic"))
+							{
+								Method method = fieldClass.getMethod("setMnemonic", new Class [] {int.class});
+								int keyCode = KeyEvent.getExtendedKeyCodeForChar(parts.get(1).toLowerCase().charAt(0)); 
+								if (keyCode != KeyEvent.VK_UNDEFINED)
+								{
+									method.invoke(field.get(_com),new Object [] {Integer.valueOf(keyCode)});
+								}
+							}
+							// END KGU#183 2016-04-24
 							// START KGU#156 2016-03-13: Enh. #124 - intended for JComboBoxes
-							else if (piece2.equalsIgnoreCase("item"))
+							else if (piece2.equals("item"))
 							{
 								// The JCombobox is supposed to be equipped with enum objects providing a setText() method
 								// (see lu.fisch.structorizer.elements.RuntimeDataPresentMode and

--- a/src/lu/fisch/structorizer/gui/Mainform.java
+++ b/src/lu/fisch/structorizer/gui/Mainform.java
@@ -181,7 +181,7 @@ public class Mainform  extends JFrame implements NSDController
 					// By first argument set to null we avoid reopening the Executor Control
 					Executor.getInstance(null, null);
 					// Since the executor is a concurrent thread and we don't know the decision of
-					// the user, we cannot neither wait nor proceeed here. So we just leave the 
+					// the user, we can neither wait nor proceed here. So we just leave.
 				}
 				else
 				// END KGU#157

--- a/src/lu/fisch/structorizer/gui/Menu.java
+++ b/src/lu/fisch/structorizer/gui/Menu.java
@@ -739,7 +739,10 @@ public class Menu extends JMenuBar implements NSDController
 
 		// Setting up Menu "Help" with all submenus and shortcuts and actions
 		menubar.add(menuHelp);
-		menuDiagram.setMnemonic(KeyEvent.VK_A);
+		// START KGU#184 2016-04-24: Bugfix #173: This overwrote the Diagram mnemonics
+		//menuDiagram.setMnemonic(KeyEvent.VK_A);
+		menuHelp.setMnemonic(KeyEvent.VK_H);
+		// END KGU#184 2016-04-24
 
 		menuHelp.add(menuHelpAbout);
 		menuHelpAbout.addActionListener(new ActionListener() { public void actionPerformed(ActionEvent event) {diagram.aboutNSD(); } } );

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -9,7 +9,7 @@ Legend:
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 <Foo>   -->     idea AND coding done by Foo
 
-Current development version: 3.24-09 (2016.04.24)
+Current development version: 3.24-10 (2016.04.24)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]
 - 01: Enh. #124: Generalized runtime data visualisation <Kay Gürtzig>
 - 01: Arranger now adopts current directory from first arranged diagram <Kay Gürtzig>
@@ -44,8 +44,10 @@ Current development version: 3.24-09 (2016.04.24)
 - 08: Issue #164: On element deletion the next element should be selected [Rolf Schmidt]
 - 08: Bugfix #165: Proper unselection on clicking outside the diagram <Kay Gürtzig>
 - 09: Issue #168: Cutting an element is to pass the selection too (cf. #164) [Rolf Schmidt]
-- 09: Issue #169: Selection ensured on start, loading an NSD, undo, redo [Rolf Schmidt]
+- 09: Issue #169: Selection ensured on new / loading an NSD, undo, redo [Rolf Schmidt]
 - 09: Bugfix #171: Twos flaws in enh. #158 mended <Kay Gürtzig>
+- 10: Issue #169: Selection ensured on start / after export [Rolf Schmidt]
+- 10: Issue #173: Menomics corrected (EN) and localized in most languages <Kay Gürtzig>
 
 Version: 3.24 (2016.03.14)
 - 01: Bugfix #50 - added return types to signature for function export in Pascal [lhoreman]

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -9,7 +9,7 @@ Legend:
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 <Foo>   -->     idea AND coding done by Foo
 
-Current development version: 3.24-10 (2016.04.24)
+Current development version: 3.24-10 (2016.04.25)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]
 - 01: Enh. #124: Generalized runtime data visualisation <Kay Gürtzig>
 - 01: Arranger now adopts current directory from first arranged diagram <Kay Gürtzig>
@@ -46,8 +46,11 @@ Current development version: 3.24-10 (2016.04.24)
 - 09: Issue #168: Cutting an element is to pass the selection too (cf. #164) [Rolf Schmidt]
 - 09: Issue #169: Selection ensured on new / loading an NSD, undo, redo [Rolf Schmidt]
 - 09: Bugfix #171: Twos flaws in enh. #158 mended <Kay Gürtzig>
-- 10: Issue #169: Selection ensured on start / after export [Rolf Schmidt]
-- 10: Issue #173: Menomics corrected (EN) and localized in most languages <Kay Gürtzig>
+- 10: Issue #30: Lexicographic string comparison enabled (Executor). <Kay Gürtzig>
+- 10: Issue #137: Output text window now automatically scrolls to end. <Kay Gürtzig>
+- 10: Issue #169: Selection ensured on start / after export. [Rolf Schmidt]
+- 10: Issue #173: Menomics corrected (EN) and localized in most languages. <Kay Gürtzig>
+- 10: Enh. #174: Input now accepts array initialisation expressions. <Kay Gürtzig>
 
 Version: 3.24 (2016.03.14)
 - 01: Bugfix #50 - added return types to signature for function export in Pascal [lhoreman]

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -49,7 +49,7 @@ Current development version: 3.24-10 (2016.04.25)
 - 10: Issue #30: Lexicographic string comparison enabled (Executor). <Kay Gürtzig>
 - 10: Issue #137: Output text window now automatically scrolls to end. <Kay Gürtzig>
 - 10: Issue #169: Selection ensured on start / after export. [Rolf Schmidt]
-- 10: Issue #173: Menomics corrected (EN) and localized in most languages. <Kay Gürtzig>
+- 10: Issue #173: Mnemonics corrected (EN) and localized in most languages. <Kay Gürtzig>
 - 10: Enh. #174: Input now accepts array initialisation expressions. <Kay Gürtzig>
 
 Version: 3.24 (2016.03.14)

--- a/src/lu/fisch/structorizer/gui/cz.txt
+++ b/src/lu/fisch/structorizer/gui/cz.txt
@@ -29,9 +29,10 @@
  *
  *      Revision List
  *
- *      Author          Date			Description
- *      ------		----			-----------
- *      Vaščák Vladimír     2010.11.04      	Created
+ *      Author          Date            Description
+ *      ------          ----            -----------
+ *      Vaščák Vladimír 2010.11.04      Created
+ *      Kay Gürtzig     2016.04.24      Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -42,6 +43,7 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=Soubor
+Menu.menuFile.mnemonic=s
 // Submenus of "File"
 Menu.menuFileNew.text=Nový
 Menu.menuFileOpen.text=Otevřít ...
@@ -58,6 +60,7 @@ Menu.menuFilePrint.text=Tisk ...
 Menu.menuFileQuit.text=Konec
 // Menu "Edit"
 Menu.menuEdit.text=Úpravy
+Menu.menuEdit.mnemonic=u
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Zpět
 Menu.menuEditRedo.text=Znovu
@@ -68,6 +71,7 @@ Menu.menuEditCopyDiagramPNG.text=Kopírovat PNG obrázek
 Menu.menuEditCopyDiagramEMF.text=Kopírovat EMF obrázek
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagram
+Menu.menuDiagram.mnemonic=d
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Přidat
 // Submenu "Diagram -> Add -> Before"
@@ -105,9 +109,10 @@ Menu.menuDiagramNice.text=Hranatý diagram?
 Menu.menuDiagramComment.text=Ukazovat komentáře?
 Menu.menuDiagramMarker.text=Zvýraznit proměnné?
 Menu.menuDiagramDIN.text=DIN?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Nastavení
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=n
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Písmo ...
 Menu.menuPreferencesColors.text=Barvy ...
 Menu.menuPreferencesOptions.text=Struktury ...
@@ -127,6 +132,7 @@ Menu.menuPreferencesLookAndFeel.text=Vzhled
 Menu.menuPreferencesSave.text=Uložit nyní všechna nastavení
 // Menu "Help"
 Menu.menuHelp.text=Nápověda
+Menu.menuHelp.mnemonic=p
 // Submenu of "Help"
 Menu.menuHelpAbout.text=O programu ...
 Menu.menuHelpUpdate.text=Aktualizace ...

--- a/src/lu/fisch/structorizer/gui/de.txt
+++ b/src/lu/fisch/structorizer/gui/de.txt
@@ -46,6 +46,7 @@
  *      Kay Gürtzig         2016.04.01  Enh. #144: New ExportOptionDialog and Menu messages
  *      Kay Gürtzig         2016.04.04  Issue #149: New ExportOptionDialog messages for charset setting
  *      Kay Gürtzig         2016.04.12  Issue #161: New Analyser error message for Jump
+ *      Kay Gürtzig         2016.04.24  Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -56,6 +57,7 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=Datei
+Menu.menuFile.mnemonic=d
 // Submenus of "File"
 Menu.menuFileNew.text=Neu
 Menu.menuFileOpen.text=Öffnen ...
@@ -76,6 +78,7 @@ Menu.menuFileArrange.text=Im Arranger anordnen
 Menu.menuFileQuit.text=Beenden
 // Menu "Edit"
 Menu.menuEdit.text=Bearbeiten
+Menu.menuEdit.mnemonic=e
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Rückgängig machen
 Menu.menuEditRedo.text=Wiederholen
@@ -86,6 +89,7 @@ Menu.menuEditCopyDiagramPNG.text=Als PNG Grafik kopieren
 Menu.menuEditCopyDiagramEMF.text=Als EMF Grafik kopieren
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagramme
+Menu.menuDiagram.mnemonic=g
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Hinzufügen
 // Submenu "Diagram -> Add -> Before"
@@ -134,9 +138,10 @@ Menu.menuDiagramMarker.text=Hervorheben von Variablen?
 Menu.menuDiagramDIN.text=DIN 66261?
 Menu.menuDiagramAnalyser.text=Struktogramm überprüfen?
 Menu.menuDiagramWheel.text=Mausrad zum Reduzieren?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Einstellungen
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=s
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Zeichensätze ...
 Menu.menuPreferencesColors.text=Farben ...
 Menu.menuPreferencesOptions.text=Strukturen ...
@@ -168,6 +173,7 @@ Menu.menuPreferencesSaveLoad.text=Laden ...
 
 // Menu "Help"
 Menu.menuHelp.text=Hilfe
+Menu.menuHelp.mnemonic=h
 // Submenu of "Help"
 Menu.menuHelpAbout.text=Über Structorizer ...
 Menu.menuHelpUpdate.text=Neue Versionen ...

--- a/src/lu/fisch/structorizer/gui/en.txt
+++ b/src/lu/fisch/structorizer/gui/en.txt
@@ -46,6 +46,7 @@
  *      Kay Gürtzig     2016-04-02      Messages para #144 (ExportOptionDialoge and Menu)
  *      Kay Gürtzig     2016.04.04      Issue #149: New ExportOptionDialog messages for charset setting
  *      Kay Gürtzig     2016.04.12      Issue #161: New Analyser error message for Jump
+ *      Kay Gürtzig     2016.04.24      Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -56,6 +57,7 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=File
+Menu.menuFile.mnemonic=f
 // Submenus of "File"
 Menu.menuFileNew.text=New
 Menu.menuFileOpen.text=Open ...
@@ -76,6 +78,7 @@ Menu.menuFileArrange.text=Arrange
 Menu.menuFileQuit.text=Quit
 // Menu "Edit"
 Menu.menuEdit.text=Edit
+Menu.menuEdit.mnemonic=e
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Undo
 Menu.menuEditRedo.text=Redo
@@ -86,6 +89,7 @@ Menu.menuEditCopyDiagramPNG.text=Copy PNG image
 Menu.menuEditCopyDiagramEMF.text=Copy EMF image
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagram
+Menu.menuDiagram.mnemonic=d
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Add
 // Submenu "Diagram -> Add -> Before"
@@ -133,9 +137,10 @@ Menu.menuDiagramMarker.text=Highlight variables?
 Menu.menuDiagramDIN.text=DIN?
 Menu.menuDiagramAnalyser.text=Analyse structogram?
 Menu.menuDiagramWheel.text=Mouse wheel for collapsing?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Preferences
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=p
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Font ...
 Menu.menuPreferencesColors.text=Colors ...
 Menu.menuPreferencesOptions.text=Structures ...
@@ -167,6 +172,7 @@ Menu.menuPreferencesSaveLoad.text=Load from file ...
 
 // Menu "Help"
 Menu.menuHelp.text=Help
+Menu.menuHelp.mnemonic=h
 // Submenu of "Help"
 Menu.menuHelpAbout.text=About ...
 Menu.menuHelpUpdate.text=Update ...

--- a/src/lu/fisch/structorizer/gui/es.txt
+++ b/src/lu/fisch/structorizer/gui/es.txt
@@ -43,9 +43,10 @@
  *      Kay Gürtzig     2016.03.18  Initial question marks added
  *      Kay Gürtzig     2016.03.22  Enh. #84: messages related to FOR-IN loops added
  *      Kay Gürtzig     2016.03.31  Enh. #23: messages related to JUMP configuration added
- *      Kay Gürtzig     2016-04-02  Messages para #144 (ExportOptionDialoge and Menu)
+ *      Kay Gürtzig     2016-04-02  Messages for #144 (ExportOptionDialoge and Menu)
  *      Kay Gürtzig     2016.04.04  Issue #149: New ExportOptionDialog messages for charset setting
  *      Kay Gürtzig     2016.04.12  Issue #161: New Analyser error message for Jump
+ *      Kay Gürtzig     2016.04.24  Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -56,10 +57,11 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=Archivo
+Menu.menuFile.mnemonic=a
 // Submenus of "File"
 Menu.menuFileNew.text=Archivo
 Menu.menuFileOpen.text=Abrir ...
-Menu.menuFileOpenRecent.text=Recientemente usado
+Menu.menuFileOpenRecent.text=Reciéntemente usado
 Menu.menuFileSave.text=Guardar
 Menu.menuFileSaveAs.text=Guardar como ...
 Menu.menuFileExport.text=Exportar
@@ -77,6 +79,7 @@ Menu.menuFileArrange.text=Colocar en el Arranger
 Menu.menuFileQuit.text=Salir
 // Menu "Edit"
 Menu.menuEdit.text=Editar
+Menu.menuEdit.mnemonic=e
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Deshacer
 Menu.menuEditRedo.text=Rehacer
@@ -87,6 +90,7 @@ Menu.menuEditCopyDiagramPNG.text=Copiar Imagen PNG
 Menu.menuEditCopyDiagramEMF.text=Copiar Imagen EMF
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagrama
+Menu.menuDiagram.mnemonic=d
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Agregar
 // Submenu "Diagram -> Add -> Before"
@@ -134,9 +138,10 @@ Menu.menuDiagramMarker.text=¿Resaltar variables?
 Menu.menuDiagramDIN.text=¿DIN?
 Menu.menuDiagramAnalyser.text=¿Comprobar diagrama?
 Menu.menuDiagramWheel.text=¿Usar rueda para reducir?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Preferencias
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=p
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Fuente ...
 Menu.menuPreferencesColors.text=Colores ...
 Menu.menuPreferencesOptions.text=Estructuras ...
@@ -167,6 +172,7 @@ Menu.menuPreferencesSaveLoad.text=Importar de un archivo ...
 
 // Menu "Help"
 Menu.menuHelp.text=Ayuda
+Menu.menuHelp.mnemonic=y
 // Submenu of "Help"
 Menu.menuHelpAbout.text=Acerca de ...
 Menu.menuHelpUpdate.text=Actualizar ...

--- a/src/lu/fisch/structorizer/gui/fr.txt
+++ b/src/lu/fisch/structorizer/gui/fr.txt
@@ -29,9 +29,10 @@
  *
  *      Revision List
  *
- *      Author          Date			Description
- *      ------		----			-----------
- *      Bob Fisch       2008.01.14      	First Issue
+ *      Author          Date            Description
+ *      ------          ----            -----------
+ *      Bob Fisch       2008.01.14      First Issue
+ *      Kay Gürtzig     2016.04.24      Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -42,6 +43,7 @@
  -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=Fichier
+Menu.menuFile.mnemonic=f
 // Submenus of "File"
 Menu.menuFileNew.text=Nouveau
 Menu.menuFileOpen.text=Ouvrir ...
@@ -58,6 +60,7 @@ Menu.menuFilePrint.text=Imprimer ...
 Menu.menuFileQuit.text=Quitter
 // Menu "Edit"
 Menu.menuEdit.text=Editer
+Menu.menuEdit.mnemonic=e
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Annuler
 Menu.menuEditRedo.text=Annuler annuler
@@ -68,6 +71,7 @@ Menu.menuEditCopyDiagramPNG.text=Copier l'image (PNG)
 Menu.menuEditCopyDiagramEMF.text=Copier l'image (EMF)
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagramme
+Menu.menuDiagram.mnemonic=d
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Ajouter
 // Submenu "Diagram -> Add -> Before"
@@ -105,9 +109,10 @@ Menu.menuDiagramNice.text=Diagramme cadré
 Menu.menuDiagramComment.text=Montrer les commentaires?
 Menu.menuDiagramMarker.text=Marquer les variables?
 Menu.menuDiagramDIN.text=DIN?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Préférences
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=p
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Police ...
 Menu.menuPreferencesColors.text=Couleurrs ...
 Menu.menuPreferencesOptions.text=Structures ...
@@ -121,7 +126,7 @@ Menu.menuPreferencesLanguageLuxemburgish.text=Luxembourgeois
 Menu.menuPreferencesLanguageSpanish.text=Espagnol
 Menu.menuPreferencesLanguageItalian.text=Italien
 Menu.menuPreferencesLanguagePortugalBrazil.text=Portugais (brazilien)
-Menu.menuPreferencesLanguageChinese.text=Chinois
+//Menu.menuPreferencesLanguageChinese.text=Chinois
 Menu.menuPreferencesLanguageCzech.text=Czech
 
 Menu.menuPreferencesLookAndFeel.text=Look & Feel
@@ -134,6 +139,7 @@ Menu.menuPreferencesSaveLoad.text=Charger ...
 
 // Menu "Help"
 Menu.menuHelp.text=Aide
+Menu.menuHelp.mnemonic=a
 // Submenu of "Help"
 Menu.menuHelpAbout.text=A propos de ...
 Menu.menuHelpUpdate.text=Mise à jour ...

--- a/src/lu/fisch/structorizer/gui/it.txt
+++ b/src/lu/fisch/structorizer/gui/it.txt
@@ -36,6 +36,7 @@
  *      Kay Gürtzig     2015.10.14		InputBox-specific part enhanced
  *      Kay Gürtzig     2015.10.14		FOR-specific part enhanced and Arranger buttons added
  *      Kay Gürtzig     2016.01.21      Breakpoint message also in Menu now
+ *      Kay Gürtzig     2016.04.24      Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -46,6 +47,7 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=File
+Menu.menuFile.mnemonic=f
 // Submenus of "File"
 Menu.menuFileNew.text=Nuovo
 Menu.menuFileOpen.text=Apri ...
@@ -65,6 +67,7 @@ Menu.menuFileArrange.text=Collocare in Arranger
 Menu.menuFileQuit.text=Esci
 // Menu "Edit"
 Menu.menuEdit.text=Modifica
+Menu.menuEdit.mnemonic=m
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Annula
 Menu.menuEditRedo.text=Ripeti
@@ -75,6 +78,7 @@ Menu.menuEditCopyDiagramPNG.text=Copia immagine PNG
 Menu.menuEditCopyDiagramEMF.text=Copia immagine EMF
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagramma
+Menu.menuDiagram.mnemonic=d
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Aggiungi
 // Submenu "Diagram -> Add -> Before"
@@ -115,9 +119,10 @@ Menu.menuDiagramNice.text=Stile box?
 Menu.menuDiagramComment.text=Mostra commenti?
 Menu.menuDiagramMarker.text=Evidenzia variabili?
 Menu.menuDiagramDIN.text=DIN?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Opzioni
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=o
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Caratteri ...
 Menu.menuPreferencesColors.text=Colori ...
 Menu.menuPreferencesOptions.text=Strutture ...
@@ -135,6 +140,7 @@ Menu.menuPreferencesLookAndFeel.text=Aspetto
 Menu.menuPreferencesSave.text=Salva tutte le impostazioni ora
 // Menu "Help"
 Menu.menuHelp.text=Aiuto
+Menu.menuHelp.mnemonic=a
 // Submenu of "Help"
 Menu.menuHelpAbout.text=About ...
 Menu.menuHelpUpdate.text=Aggiorna ...

--- a/src/lu/fisch/structorizer/gui/lu.txt
+++ b/src/lu/fisch/structorizer/gui/lu.txt
@@ -29,9 +29,10 @@
  *
  *      Revision List
  *
- *      Author              Date			Description
- *      ------              ----			-----------
- *      Laurent Zender      2008.01.14                  First Issue
+ *      Author              Date            Description
+ *      ------              ----            -----------
+ *      Laurent Zender      2008.01.14      First Issue
+ *      Kay Gürtzig         2016.04.24      Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -42,6 +43,7 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=File
+Menu.menuFile.mnemonic=f
 // Submenus of "File"
 Menu.menuFileNew.text=Nei
 Menu.menuFileOpen.text=Opmaachen...
@@ -58,6 +60,7 @@ Menu.menuFilePrint.text=Drécken...
 Menu.menuFileQuit.text=Verlossen
 // Menu "Edit"
 Menu.menuEdit.text=Editéieren
+Menu.menuEdit.mnemonic=e
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Réckgängig machen
 Menu.menuEditRedo.text=Erëm hierstellen
@@ -68,6 +71,7 @@ Menu.menuEditCopyDiagramPNG.text=D'Bild als PNG kopéieren
 Menu.menuEditCopyDiagramEMF.text=D'Bild als EMF kopéieren
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagram
+Menu.menuDiagram.mnemonic=d
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Bäisetzen
 // Submenu "Diagram -> Add -> Before"
@@ -105,9 +109,10 @@ Menu.menuDiagramNice.text=Boxed diagram?
 Menu.menuDiagramComment.text=Kommentaren uwëisen?
 Menu.menuDiagramMarker.text=Variablen markéieren?
 Menu.menuDiagramDIN.text=DIN?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Astellungen
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=a
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Schreft...
 Menu.menuPreferencesColors.text=Faarw...
 Menu.menuPreferencesOptions.text=Strukturen...
@@ -134,6 +139,7 @@ Menu.menuPreferencesSaveLoad.text=Lueden ...
 
 // Menu "Help"
 Menu.menuHelp.text=Hellef
+Menu.menuHelp.mnemonic=h
 // Submenu of "Help"
 Menu.menuHelpAbout.text=Iwwert...
 Menu.menuHelpUpdate.text=Update...

--- a/src/lu/fisch/structorizer/gui/nl.txt
+++ b/src/lu/fisch/structorizer/gui/nl.txt
@@ -29,9 +29,10 @@
  *
  *      Revision List
  *
- *      Author          Date			Description
- *      ------		----			-----------
- *      Jerone          ???                     First Issue
+ *      Author          Date            Description
+ *      ------          ----            -----------
+ *      Jerone          ???             First Issue
+ *      Kay Gürtzig     2016.04.24      Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -42,6 +43,7 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=Bestand
+Menu.menuFile.mnemonic=b
 // Submenus of "File"
 Menu.menuFileNew.text=Nieuw
 Menu.menuFileOpen.text=Openen ...
@@ -58,6 +60,7 @@ Menu.menuFilePrint.text=Afdrukken ...
 Menu.menuFileQuit.text=Afsluiten
 // Menu "Edit"
 Menu.menuEdit.text=Bewerken
+Menu.menuEdit.mnemonic=w
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Ongedaan maken
 Menu.menuEditRedo.text=Herhalen
@@ -68,6 +71,7 @@ Menu.menuEditCopyDiagramPNG.text=Afbeelding als PNG kopiëren
 Menu.menuEditCopyDiagramEMF.text=Afbeelding als EMF kopiëren
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagram
+Menu.menuDiagram.mnemonic=d
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Toevoegen
 // Submenu "Diagram -> Add -> Before"
@@ -105,9 +109,10 @@ Menu.menuDiagramNice.text=Boxed diagram?
 Menu.menuDiagramComment.text=Opmerkingen weergeven?
 Menu.menuDiagramMarker.text=Variabelen markeren?
 Menu.menuDiagramDIN.text=DIN?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Instellingen
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=i
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Lettertype ...
 Menu.menuPreferencesColors.text=Kleuren ...
 Menu.menuPreferencesOptions.text=Structuren ...
@@ -123,6 +128,7 @@ Menu.menuPreferencesLookAndFeel.text=Uiterlijk
 Menu.menuPreferencesSave.text=Alle instellingen nu opslaan
 // Menu "Help"
 Menu.menuHelp.text=Help
+Menu.menuHelp.mnemonic=h
 // Submenu of "Help"
 Menu.menuHelpAbout.text=Over ...
 Menu.menuHelpUpdate.text=Update ...

--- a/src/lu/fisch/structorizer/gui/pl.txt
+++ b/src/lu/fisch/structorizer/gui/pl.txt
@@ -31,7 +31,8 @@
  *
  *      Author          Date			Description
  *      ------		----			-----------
- *      Bob Fisch       2008.01.14      	First Issue
+ *      Bob Fisch       2008.01.14      First Issue
+ *      Kay Gürtzig     2016.04.24      Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -42,6 +43,7 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=Plik
+Menu.menuFile.mnemonic=p
 // Submenus of "File"
 Menu.menuFileNew.text=Nowy
 Menu.menuFileOpen.text=Otwórz ...
@@ -58,6 +60,7 @@ Menu.menuFilePrint.text=Drukuj ...
 Menu.menuFileQuit.text=Wyjdź
 // Menu "Edit"
 Menu.menuEdit.text=Edytuj
+Menu.menuEdit.mnemonic=e
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Cofnij
 Menu.menuEditRedo.text=Przywróć
@@ -68,6 +71,7 @@ Menu.menuEditCopyDiagramPNG.text=Kopiuj jako PNG
 Menu.menuEditCopyDiagramEMF.text=Kopiuj jako EMF
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagram
+Menu.menuDiagram.mnemonic=d
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Dodaj
 // Submenu "Diagram -> Add -> Before"
@@ -105,9 +109,10 @@ Menu.menuDiagramNice.text=Diagram w ramce?
 Menu.menuDiagramComment.text=Pokaż komentarze?
 Menu.menuDiagramMarker.text=Wyróżnij zmienne?
 Menu.menuDiagramDIN.text=DIN?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Preferencje
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=p
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Czcionka ...
 Menu.menuPreferencesColors.text=Kolory ...
 Menu.menuPreferencesOptions.text=Struktury ...
@@ -135,6 +140,7 @@ Menu.menuPreferencesSaveLoad.text=Odczytaj z pliku ...
 
 // Menu "Help"
 Menu.menuHelp.text=Pomoc
+Menu.menuHelp.mnemonic=p
 // Submenu of "Help"
 Menu.menuHelpAbout.text=O programie ...
 Menu.menuHelpUpdate.text=Update ...

--- a/src/lu/fisch/structorizer/gui/pt_br.txt
+++ b/src/lu/fisch/structorizer/gui/pt_br.txt
@@ -26,6 +26,7 @@
  *      ------		----			-----------
  *      PUC-Minas     2009.08.20        	First Issue
  *      PUC-Minas     2009.10.20        	Revised
+ *      Kay Gürtzig   2016.04.24        	Issue #173: New mnemonic configurations added
  *
  *****************************************************************************************************
  *
@@ -36,6 +37,7 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=Arquivo
+Menu.menuFile.mnemonic=a
 // Submenus of "File"
 Menu.menuFileNew.text=Novo
 Menu.menuFileOpen.text=Abrir ...
@@ -56,6 +58,7 @@ Menu.menuFileQuit.text=Sair
 
 // Menu "Edit"
 Menu.menuEdit.text=Editar
+Menu.menuEdit.mnemonic=e
 
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Desfazer
@@ -68,6 +71,7 @@ Menu.menuEditCopyDiagramEMF.text=Copiar imagem EMF
 
 // Menu "Diagram"
 Menu.menuDiagram.text=Diagrama
+Menu.menuDiagram.mnemonic=d
 
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Inserir
@@ -112,10 +116,11 @@ Menu.menuDiagramMarker.text=Destacar variáveis?
 Menu.menuDiagramDIN.text=DIN?
 Menu.menuDiagramAnalyser.text=Analisar diagrama?
 
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Preferências
+Menu.menuPreferences.mnemonic=p
 
-// Submenu of "Help"
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Fonte ...
 Menu.menuPreferencesColors.text=Cores ...
 Menu.menuPreferencesOptions.text=Estruturas ...
@@ -133,6 +138,7 @@ Menu.menuPreferencesSave.text=Salvar preferências agora
 
 // Menu "Help"
 Menu.menuHelp.text=Ajuda
+Menu.menuHelp.mnemonic=j
 
 // Submenu of "Help"
 Menu.menuHelpAbout.text=Sobre ...

--- a/src/lu/fisch/structorizer/gui/ru.txt
+++ b/src/lu/fisch/structorizer/gui/ru.txt
@@ -36,6 +36,7 @@
  *      Kay Gürtzig     2015.10.14		InputBox-specific part enhanced
  *      Kay Gürtzig     2016.03.22      Enh. #84: messages related to FOR-IN loops added, several
  *                                      missing messages inserted
+ *      Kay Gürtzig     2016.04.24      Issue #173: New mnemonic configurations added
  *
  ******************************************************************************************************
  *
@@ -46,6 +47,7 @@
 -----[ Menu ]-----
 //Menu File
 Menu.menuFile.text=Файл
+Menu.menuFile.mnemonic=ф
 // Submenus of "File"
 Menu.menuFileNew.text=Новый
 Menu.menuFileOpen.text=Открыть ...
@@ -64,6 +66,7 @@ Menu.menuFileArrange.text=Распределить к Arranger
 Menu.menuFileQuit.text=Выход
 // Menu "Edit"
 Menu.menuEdit.text=Правка
+Menu.menuEdit.mnemonic=р
 // Submenu of "Edit"
 Menu.menuEditUndo.text=Отменить
 Menu.menuEditRedo.text=Повторить
@@ -74,6 +77,7 @@ Menu.menuEditCopyDiagramPNG.text=Копировать изображение PNG
 Menu.menuEditCopyDiagramEMF.text=Копировать изображение EMF
 // Menu "Diagram"
 Menu.menuDiagram.text=Схема
+Menu.menuDiagram.mnemonic=с
 // Submenus of "Diagram"
 Menu.menuDiagramAdd.text=Добавить
 // Submenu "Diagram -> Add -> Before"
@@ -122,9 +126,10 @@ Menu.menuDiagramMarker.text=Подсвечивать переменные
 Menu.menuDiagramDIN.text=DIN
 Menu.menuDiagramAnalyser.text=Анализировать схему 
 Menu.menuDiagramWheel.text=Сжать с колесой?
-// Menu "Help"
+// Menu "Preferences"
 Menu.menuPreferences.text=Настройки
-// Submenu of "Help"
+Menu.menuPreferences.mnemonic=н
+// Submenu of "Preferences"
 Menu.menuPreferencesFont.text=Шрифт ...
 Menu.menuPreferencesColors.text=Цвет ...
 Menu.menuPreferencesOptions.text=Структур ...
@@ -155,6 +160,7 @@ Menu.menuPreferencesSaveLoad.text=Ввезти из файла ...
 
 // Menu "Help"
 Menu.menuHelp.text=Помощь
+Menu.menuHelp.mnemonic=п
 // Submenu of "Help"
 Menu.menuHelpAbout.text=О программе ...
 Menu.menuHelpUpdate.text=Обновления ...


### PR DESCRIPTION
(Sorry for the ephemerity of 3.24-09...)
Issue #30: Lexicographic string comparison enabled (Executor).
Issue #137: Output text window now automatically scrolls to end.
Issue #169: Selection ensured on start / after export.
Issue #173: Menu mnemomics corrected (EN) and localized in most languages (except CHS/CHT).
Enh. #174: Input now accepts array initialisation expressions.