### PR TITLE
Bugfix3.24 -> version 3.24-12 candidate

### DIFF
--- a/src/lu/fisch/structorizer/arranger/Arranger.java
+++ b/src/lu/fisch/structorizer/arranger/Arranger.java
@@ -47,6 +47,7 @@ package lu.fisch.structorizer.arranger;
  *      Kay Gürtzig     2016.03.08      Method clearExecutionStatus and btnSetCovered added (for Enhancement #77)
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data visualisation hooks
  *      Kay Gürtzig     2016-04-14      Enh. #158 (KGU#177): Keys for copy and paste enabled, closing mechanism modified
+ *      Kay Gürtzig     2016-07-03      Dialog message translation mechanism added (KGU#203). 
  *
  ******************************************************************************************************
  *
@@ -68,6 +69,7 @@ import javax.swing.JScrollPane;
 import lu.fisch.structorizer.elements.Element;
 import lu.fisch.structorizer.elements.Root;
 import lu.fisch.structorizer.executor.IRoutinePool;
+import lu.fisch.structorizer.gui.LangDialog;
 import lu.fisch.structorizer.gui.Mainform;
 
 /**
@@ -425,6 +427,13 @@ public class Arranger extends javax.swing.JFrame implements WindowListener, KeyL
         surface.setCovered(this);
     }
     // END KGU#88 2016-03-09
+    
+    // START KGU#202 2016-07-03: Language support for dependent Arranger
+    public void setLangLocal(String _langfile)
+    {
+    	LangDialog.setLang(this.surface, _langfile);
+    }
+    // END KGU#202 2016-07-03
 
     /**
      * Starts the Arranger as application

--- a/src/lu/fisch/structorizer/arranger/de.txt
+++ b/src/lu/fisch/structorizer/arranger/de.txt
@@ -1,0 +1,57 @@
+/*
+    Structorizer English language file
+
+    Copyright (C) 2009  Bob Fisch
+
+    This file is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or any
+    later version.
+
+    This file is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file is part of the "Structorizer" project.     
+*/
+
+/******************************************************************************************************
+ *
+ *      Author:         Kay Gürtzig
+ *
+ *      Description:    The German language file for Arranger
+ *
+ ******************************************************************************************************
+ *
+ *      Revision List
+ *
+ *      Author          Date            Description
+ *      ------          ----            -----------
+ *      Kay Gürtzig     2016.07.03      First Issue.
+ *
+ ******************************************************************************************************
+ *
+ *      Comment:	
+ *
+ ******************************************************************************************************/
+
+Surface.msgFileLoadError.text=Dateiladefehler:
+Surface.msgSavePortable.text=Als portables komprimiertes Archiv sichern?
+Surface.msgSaveDialogTitle.text=Speichere die Diagrammanordnung ...
+Surface.msgSaveError.text=Fehler beim Sichern der Anordnung:
+Surface.msgLoadDialogTitle.text=Gespeicherte Diagrammanordnung laden ...
+Surface.msgExtractDialogTitle.text=In ein Verzeichnis entpacken?
+Surface.msgArrLoadError.text=Fehler beim Laden der Anordnung:
+Surface.msgExportDialogTitle.text=Exportiere Diagramm als PNG ...
+Surface.msgExportError.text=Fehler beim Erzeugen der Bilddatei!
+Surface.msgParseError.text=NSD-Parser-Fehler:
+Surface.msgResetCovered.text=Routine ist bereits als testabgedeckt markiert! Markierung aufheben?
+Surface.msgCoverageError.text=Kein geeignetes Unterprogramm-Diagramm ausgewählt, keine Abdeckungs-Markierung möglich!
+Surface.msgUnsavedDiagrams.text=Folgende Diagramme konnten nicht gesichert werden:
+Surface.msgUnsavedHint.text=Vielleicht möchten Sie die Diagramme erst per Doppelklick von einem Structorizer sichern lassen.
+Surface.msgUnsavedContinue.text=Trotzdem fortfahren?
+Surface.msgNoArrFile.text=Keine Arranger-Datei (arr) gefunden

--- a/src/lu/fisch/structorizer/arranger/en.txt
+++ b/src/lu/fisch/structorizer/arranger/en.txt
@@ -1,0 +1,57 @@
+/*
+    Structorizer English language file
+
+    Copyright (C) 2009  Bob Fisch
+
+    This file is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or any
+    later version.
+
+    This file is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file is part of the "Structorizer" project.     
+*/
+
+/******************************************************************************************************
+ *
+ *      Author:         Kay Gürtzig
+ *
+ *      Description:    The English language file for Arranger
+ *
+ ******************************************************************************************************
+ *
+ *      Revision List
+ *
+ *      Author          Date            Description
+ *      ------          ----            -----------
+ *      Kay Gürtzig     2016.07.03      First Issue.
+ *
+ ******************************************************************************************************
+ *
+ *      Comment:	
+ *
+ ******************************************************************************************************/
+
+Surface.msgFileLoadError.text=File Load Error:
+Surface.msgSavePortable.text=Save as portable compressed archive?
+Surface.msgSaveDialogTitle.text=Save arranged set of diagrams ...
+Surface.msgSaveError.text=Error on saving the arrangement:
+Surface.msgLoadDialogTitle.text=Reload a stored arrangement of diagrams ...
+Surface.msgExtractDialogTitle.text=Extract to a directory?
+Surface.msgArrLoadError.text=Error on loading the arrangement:
+Surface.msgExportDialogTitle.text=Export diagram as PNG ...
+Surface.msgExportError.text=Error while saving the image!
+Surface.msgParseError.text=NSD Parser Error:
+Surface.msgResetCovered.text=Routine is already marked as test-covered! Reset coverage mark?
+Surface.msgCoverageError.text=No suitable routine diagram selected, cannot mark anything as covered!
+Surface.msgUnsavedDiagrams.text=Couldn't save these diagrams:
+Surface.msgUnsavedHint.text=You might want to double-click and save them via Structorizer first.
+Surface.msgUnsavedContinue.text=Continue nevertheless?
+Surface.msgNoArrFile.text=No Arranger file found

--- a/src/lu/fisch/structorizer/arranger/es.txt
+++ b/src/lu/fisch/structorizer/arranger/es.txt
@@ -1,0 +1,57 @@
+/*
+    Structorizer English language file
+
+    Copyright (C) 2009  Bob Fisch
+
+    This file is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or any
+    later version.
+
+    This file is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file is part of the "Structorizer" project.     
+*/
+
+/******************************************************************************************************
+ *
+ *      Author:         Kay Gürtzig
+ *
+ *      Description:    The Spanish language file for Arranger
+ *
+ ******************************************************************************************************
+ *
+ *      Revision List
+ *
+ *      Author          Date            Description
+ *      ------          ----            -----------
+ *      Kay Gürtzig     2016.07.03      First Issue.
+ *
+ ******************************************************************************************************
+ *
+ *      Comment:	
+ *
+ ******************************************************************************************************/
+
+Surface.msgFileLoadError.text=Error abriendo archivo:
+Surface.msgSavePortable.text=¿Guardar como archivo portable y comprimido?
+Surface.msgSaveDialogTitle.text=Guarda colocado conjunto de diagramas ...
+Surface.msgSaveError.text=Error guardando la colocación:
+Surface.msgLoadDialogTitle.text=Restablezca guardado conjunto de diagramas ...
+Surface.msgExtractDialogTitle.text=¿Extraer a un directorio?
+Surface.msgArrLoadError.text=Error leyendo la colocación:
+Surface.msgExportDialogTitle.text=Exporta diagrama como PNG ...
+Surface.msgExportError.text=¡Error guardando el imagen!
+Surface.msgParseError.text=NSD Parser Error:
+Surface.msgResetCovered.text=Subprograma ya marcado como cubierto. ¿Quitar marca de cobertura?
+Surface.msgCoverageError.text=No subprograma apropiado seleccionado, ¡no va a ser marcado como cubierto nada!
+Surface.msgUnsavedDiagrams.text=Estos diagramas no fueron guardados:
+Surface.msgUnsavedHint.text=Para guardarlos por Structorizer anteriormente haga un doble clic a los diagramas.
+Surface.msgUnsavedContinue.text=¿Continuar aun así?
+Surface.msgNoArrFile.text=Ningún Arranger archivo encontrado

--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -148,7 +148,7 @@ import javax.swing.ImageIcon;
 
 public abstract class Element {
 	// Program CONSTANTS
-	public static String E_VERSION = "3.24-11";
+	public static String E_VERSION = "3.24-12dev";
 	public static String E_THANKS =
 	"Developed and maintained by\n"+
 	" - Robert Fisch <robert.fisch@education.lu>\n"+

--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -148,7 +148,7 @@ import javax.swing.ImageIcon;
 
 public abstract class Element {
 	// Program CONSTANTS
-	public static String E_VERSION = "3.24-12dev";
+	public static String E_VERSION = "3.24-12";
 	public static String E_THANKS =
 	"Developed and maintained by\n"+
 	" - Robert Fisch <robert.fisch@education.lu>\n"+

--- a/src/lu/fisch/structorizer/executor/Control.java
+++ b/src/lu/fisch/structorizer/executor/Control.java
@@ -38,9 +38,10 @@ package lu.fisch.structorizer.executor;
  *      Kay Gürtzig     2016.03.06      Enh. #77: New checkboxes for test coverage tracking mode (KGU#117)
  *      Kay Gürtzig     2016.03.13      Enh. #124 (KGU#156): Runtime data collection generalised
  *      Kay Gürtzig     2016.03.17      Enh. #133 (KGU#159): Stack trace may now be shown in paused mode
- *      Kay Gürtzig     2016.03.18      Enh. #89 Extended Language translation support
+ *      Kay Gürtzig     2016.03.18      KGU#89: Extended Language translation support
  *      Kay Gürtzig     2016.03.25      Message translations now held in LangTextHolder instead of JLabel
  *      Kay Gürtzig     2016.04.12      Enh. #137: additional toggle to direct input and output to a text window
+ *      Kay Gürtzig     2016.05.05      KGU#197: Further (forgotten) LangTextHolders added
  *
  ******************************************************************************************************
  *
@@ -120,11 +121,21 @@ public class Control extends javax.swing.JFrame implements PropertyChangeListene
         // END KGU#2 (#9) 2015-11-14
 
         // START KGU#89/KGU#157 2016-03-18: Bugfix #131 - Prevent interference or take-over
-        // This is just a dummy label as translation support for Executor
+        // These fields are just a translation support for Executor
         lbStopRunningProc = new LangTextHolder("This action is not allowed while a diagram is being executed.\nDo you want to stop the current execution?");
         lbInputValue = new LangTextHolder("Please enter a value for <%>");
         lbInputPaused = new LangTextHolder("Execution paused - you may enter the value in the variable display.");
         // END KGU#89/KGU#157 2016-03-18
+        // START KGU#197 2016-05-05: Forgotten translations added
+        lbInputCancelled = new LangTextHolder("Input cancelled");
+        lbManuallySet = new LangTextHolder("*** Manually set: %1 <- %2 ***");
+        lbEmptyLine = new LangTextHolder("empty line");
+        lbNoCorrectExpr = new LangTextHolder("<%> is not a correct or existing expression.");
+        lbReturnedResult = new LangTextHolder("Returned result");
+        lbOutput = new LangTextHolder("Output");
+        lbInput = new LangTextHolder("Input");
+        lbAcknowledge = new LangTextHolder("Please acknowledge.");
+        // END KGU#197 2016-05-05
 
         setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
 
@@ -538,6 +549,16 @@ public class Control extends javax.swing.JFrame implements PropertyChangeListene
     public LangTextHolder lbInputValue;
     public LangTextHolder lbInputPaused;
     // END KGU#89/KGU#157 2016-03-18
+    // START KGU#197 2016-05-05: More language support
+    public LangTextHolder lbInputCancelled;
+    public LangTextHolder lbManuallySet;
+    public LangTextHolder lbEmptyLine;
+    public LangTextHolder lbNoCorrectExpr;
+    public LangTextHolder lbReturnedResult;
+    public LangTextHolder lbOutput;
+    public LangTextHolder lbInput;
+    public LangTextHolder lbAcknowledge;
+    // START KGU#197 2016-05-05
     
     // START KGU#68 2015-11-06: Register variable value editing events
     private Object[] varUpdates = null;

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -888,6 +888,9 @@ public class Executor implements Runnable
 							this.returnedValue = resObj;
 							if (this.callers.isEmpty())
 							{
+								// START KGU#197 2016-05-25: Translate the headline!
+								String header = control.lbReturnedResult.getText();
+								// END KGU#197 2016-05-25
 								// START KGU#133 2016-01-09: Show large arrays in a listview
 								//JOptionPane.showMessageDialog(diagram, n,
 								//		"Returned result", JOptionPane.INFORMATION_MESSAGE);
@@ -896,7 +899,7 @@ public class Executor implements Runnable
 								{
 									// START KGU#147 2016-01-29: Enh. #84 - interface changed for more flexibility
 									//showArray((Object[])resObj, "Returned result");
-									showArray((Object[])resObj, "Returned result", !step);
+									showArray((Object[])resObj, header, !step);
 									// END KGU#147 2016-01-29
 								}
 								// START KGU#84 2015-11-23: Enhancement to give a chance to pause (though of little use here)
@@ -908,18 +911,18 @@ public class Executor implements Runnable
 								else if (step)
 								{
 									// START KGU#160 2016-04-26: Issue #137 - also log the result to the console
-									this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
+									this.console.writeln("*** " + header + ": " + this.prepareValueForDisplay(resObj), Color.CYAN);
 									// END KGU#160 2016-04-26
 									JOptionPane.showMessageDialog(diagram, resObj,
-											"Returned result", JOptionPane.INFORMATION_MESSAGE);
+											header, JOptionPane.INFORMATION_MESSAGE);
 								}
 								else
 								{
 									// START KGU#198 2016-05-25: Issue #137 - also log the result to the console
-									this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
+									this.console.writeln("*** " + header + ": " + this.prepareValueForDisplay(resObj), Color.CYAN);
 									// END KGU#198 2016-05-25
 									Object[] options = {"OK", "Pause"};		// FIXME: Provide a translation
-									int pressed = JOptionPane.showOptionDialog(diagram, resObj, "Returned result",
+									int pressed = JOptionPane.showOptionDialog(diagram, resObj, header,
 											JOptionPane.OK_CANCEL_OPTION, JOptionPane.INFORMATION_MESSAGE, null, options, null);
 									if (pressed == 1)
 									{

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -50,14 +50,23 @@ package lu.fisch.structorizer.executor;
  *      Kay Gürtzig     2015.11.11      Issue #21 KGU#77 fixed: return instructions didn't terminate the execution.
  *      Kay Gürtzig     2015.11.12      Bugfix KGU#79: WHILE condition wasn't effectively converted.
  *      Kay Gürtzig     2015.11.13/14   Enhancement #9 (KGU#2) to allow the execution of subroutine calls
+
  *      Kay Gürtzig     2015.11.20      Bugfix KGU#86: Interpreter was improperly set up for functions sqr, sqrt;
+
  *                                      Message types for output and return value information corrected
+
  *      Kay Gürtzig     2015.11.23      Enhancement #36 (KGU#84) allowing to pause from input and output dialogs.
+
  *      Kay Gürtzig     2015.11.24/25   Enhancement #9 (KGU#2) enabling the execution of calls accomplished.
+
  *      Kay Gürtzig     2015.11.25/27   Enhancement #23 (KGU#78) to handle Jump elements properly.
+
  *      Kay Gürtzig     2015.12.10      Bugfix #49 (KGU#99): wrapper objects in variables obstructed comparison,
+
  *                                      ER #48 (KGU#97) w.r.t. delay control of diagramControllers
+
  *      Kay Gürtzig     2015.12.11      Enhancement #54 (KGU#101): List of output expressions
+
  *      Kay Gürtzig     2015.12.13      Enhancement #51 (KGU#107): Handling of empty input and output
  *      Kay Gürtzig     2015.12.15/26   Bugfix #61 (KGU#109): Precautions against type specifiers
  *      Kay Gürtzig     2016.01.05      Bugfix #90 (KGU#125): Arranger updating for executed subroutines fixed
@@ -84,6 +93,7 @@ package lu.fisch.structorizer.executor;
  *      Kay Gürtzig     2016-04-26      KGU#150: ord implementation revised,
  *                                      Enh. #137 (KGU#160): Arguments and results added to text window output
  *      Kay Gürtzig     2016.05.05      KGU#197: Further (forgotten) texts put under language support
+ *      Kay Gürtzig     2016.05.25      KGU#198: top-level function results weren't logged in the window output
  *
  ******************************************************************************************************
  *
@@ -887,6 +897,9 @@ public class Executor implements Runnable
 							this.returnedValue = resObj;
 							if (this.callers.isEmpty())
 							{
+								// START KGU#198 2016-05-25: Issue #137 - also log the result to the console
+								this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
+								// END KGU#198 2016-05-25
 								// START KGU#133 2016-01-09: Show large arrays in a listview
 								//JOptionPane.showMessageDialog(diagram, n,
 								//		"Returned result", JOptionPane.INFORMATION_MESSAGE);
@@ -907,7 +920,7 @@ public class Executor implements Runnable
 								else if (step)
 								{
 									// START KGU#160 2016-04-26: Issue #137 - also log the result to the console
-									this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
+									//this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
 									// END KGU#160 2016-04-26
 									JOptionPane.showMessageDialog(diagram, resObj,
 											"Returned result", JOptionPane.INFORMATION_MESSAGE);

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -1,4 +1,4 @@
-﻿/*
+/*
     Structorizer
     A little tool which you can use to create Nassi-Schneiderman Diagrams (NSD)
 
@@ -50,23 +50,14 @@ package lu.fisch.structorizer.executor;
  *      Kay Gürtzig     2015.11.11      Issue #21 KGU#77 fixed: return instructions didn't terminate the execution.
  *      Kay Gürtzig     2015.11.12      Bugfix KGU#79: WHILE condition wasn't effectively converted.
  *      Kay Gürtzig     2015.11.13/14   Enhancement #9 (KGU#2) to allow the execution of subroutine calls
-
  *      Kay Gürtzig     2015.11.20      Bugfix KGU#86: Interpreter was improperly set up for functions sqr, sqrt;
-
  *                                      Message types for output and return value information corrected
-
  *      Kay Gürtzig     2015.11.23      Enhancement #36 (KGU#84) allowing to pause from input and output dialogs.
-
  *      Kay Gürtzig     2015.11.24/25   Enhancement #9 (KGU#2) enabling the execution of calls accomplished.
-
  *      Kay Gürtzig     2015.11.25/27   Enhancement #23 (KGU#78) to handle Jump elements properly.
-
  *      Kay Gürtzig     2015.12.10      Bugfix #49 (KGU#99): wrapper objects in variables obstructed comparison,
-
  *                                      ER #48 (KGU#97) w.r.t. delay control of diagramControllers
-
  *      Kay Gürtzig     2015.12.11      Enhancement #54 (KGU#101): List of output expressions
-
  *      Kay Gürtzig     2015.12.13      Enhancement #51 (KGU#107): Handling of empty input and output
  *      Kay Gürtzig     2015.12.15/26   Bugfix #61 (KGU#109): Precautions against type specifiers
  *      Kay Gürtzig     2016.01.05      Bugfix #90 (KGU#125): Arranger updating for executed subroutines fixed
@@ -897,9 +888,6 @@ public class Executor implements Runnable
 							this.returnedValue = resObj;
 							if (this.callers.isEmpty())
 							{
-								// START KGU#198 2016-05-25: Issue #137 - also log the result to the console
-								this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
-								// END KGU#198 2016-05-25
 								// START KGU#133 2016-01-09: Show large arrays in a listview
 								//JOptionPane.showMessageDialog(diagram, n,
 								//		"Returned result", JOptionPane.INFORMATION_MESSAGE);
@@ -920,13 +908,16 @@ public class Executor implements Runnable
 								else if (step)
 								{
 									// START KGU#160 2016-04-26: Issue #137 - also log the result to the console
-									//this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
+									this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
 									// END KGU#160 2016-04-26
 									JOptionPane.showMessageDialog(diagram, resObj,
 											"Returned result", JOptionPane.INFORMATION_MESSAGE);
 								}
 								else
 								{
+									// START KGU#198 2016-05-25: Issue #137 - also log the result to the console
+									this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
+									// END KGU#198 2016-05-25
 									Object[] options = {"OK", "Pause"};		// FIXME: Provide a translation
 									int pressed = JOptionPane.showOptionDialog(diagram, resObj, "Returned result",
 											JOptionPane.OK_CANCEL_OPTION, JOptionPane.INFORMATION_MESSAGE, null, options, null);
@@ -2529,6 +2520,9 @@ public class Executor implements Runnable
 				// END KGU#133 2016-01-29
 				} else
 				{
+					// START KGU#198 2016-05-25: Issue #137 - also log the result to the console
+					this.console.writeln("*** " + header + ": " + this.prepareValueForDisplay(resObj), Color.CYAN);
+					// END KGU#198 2016-05-25
 					// START KGU#84 2015-11-23: Enhancement to give a chance to pause (though of little use here)
 					Object[] options = {"OK", "Pause"};		// FIXME: Provide a translation
 					int pressed = JOptionPane.showOptionDialog(diagram, resObj, header,

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -85,6 +85,7 @@ package lu.fisch.structorizer.executor;
  *                                      Enh. #137 (KGU#160): Arguments and results added to text window output
  *      Kay Gürtzig     2016.05.05      KGU#197: Further (forgotten) texts put under language support
  *      Kay Gürtzig     2016.05.25      KGU#198: top-level function results weren't logged in the window output
+ *      Kay Gürtzig     2016.06.07      KGU#200: While loops showed wrong colour if their body raised an error
  *
  ******************************************************************************************************
  *
@@ -2898,10 +2899,16 @@ public class Executor implements Runnable
 					}
 					// END KGU#117 2016-03-07
 
-					element.executed = true;
-					element.waited = false;
+					// START KGU#200 2016-06-07: Body is only done if there was no error
+					//element.executed = true;
+					//element.waited = false;
+					// END KGU#200 2016-06-07
 					if (result.equals(""))
 					{
+						// START KGU#200 2016-06-07: If body is done without error then show loop as active again
+						element.executed = true;
+						element.waited = false;
+						// END KGU#200 2016-06-07
 						//cw++;
 						// START KGU 2015-10-13: Symbolizes the loop condition check 
 						checkBreakpoint(element);

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
     Structorizer
     A little tool which you can use to create Nassi-Schneiderman Diagrams (NSD)
 
@@ -83,6 +83,7 @@ package lu.fisch.structorizer.executor;
  *                                      Enh. #174 (KGU#184): Input now accepts array initialisation expressions
  *      Kay Gürtzig     2016-04-26      KGU#150: ord implementation revised,
  *                                      Enh. #137 (KGU#160): Arguments and results added to text window output
+ *      Kay Gürtzig     2016.05.05      KGU#197: Further (forgotten) texts put under language support
  *
  ******************************************************************************************************
  *
@@ -1734,6 +1735,7 @@ public class Executor implements Runnable
 	// START KGU#68 2015-11-06
 	public void adoptVarChanges(Object[] newValues)
 	{
+		String tmplManuallySet = control.lbManuallySet.getText();	// The message template
 		for (int i = 0; i < newValues.length; i++)
 		{
 			if (newValues[i] != null)
@@ -1742,7 +1744,10 @@ public class Executor implements Runnable
 					String varName = this.variables.get(i);
 					Object oldValue = interpreter.get(varName);
 					// START KGU#160 2016-04-12: Enh. #137 - text window output
-					this.console.writeln("*** Manually set: " + varName + " <- " + newValues[i] + " ***", Color.RED);
+					// START KGU#197 2016-05-05: Language support extended
+					//this.console.writeln("*** Manually set: " + varName + " <- " + newValues[i] + " ***", Color.RED);
+					this.console.writeln(tmplManuallySet.replace("%1", varName).replace("%2", newValues[i].toString()), Color.RED);
+					// END KGU#197 2016-05-05
 					if (isConsoleEnabled)
 					{
 						this.console.setVisible(true);
@@ -2284,7 +2289,7 @@ public class Executor implements Runnable
 		{
 			// In run mode, give the user a chance to intervene
 			Object[] options = {"OK", "Pause"};	// FIXME: Provide a translation
-			int pressed = JOptionPane.showOptionDialog(diagram, "Please acknowledge.", "Input",
+			int pressed = JOptionPane.showOptionDialog(diagram, control.lbAcknowledge.getText(), control.lbInput.getText(),
 					JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, null);
 			if (pressed == 1)
 			{
@@ -2344,8 +2349,12 @@ public class Executor implements Runnable
 			if (str == null)
 			{
 				// Switch to step mode such that the user may enter the variable in the display and go on
-				JOptionPane.showMessageDialog(diagram, "Execution paused - you may enter the value in the variable display.",
-						"Input cancelled", JOptionPane.WARNING_MESSAGE);
+				// START KGU#197 2016-05-05: Issue #89
+				//JOptionPane.showMessageDialog(diagram, "Execution paused - you may enter the value in the variable display.",
+				//		"Input cancelled", JOptionPane.WARNING_MESSAGE);
+				JOptionPane.showMessageDialog(diagram, control.lbInputPaused.getText(),
+						control.lbInputCancelled.getText(), JOptionPane.WARNING_MESSAGE);
+				// START KGU#197 2016-05-05
 				paus = true;
 				step = true;
 				this.control.setButtonsForPause();
@@ -2397,9 +2406,7 @@ public class Executor implements Runnable
 				Object n = interpreter.eval(out);
 				if (n == null)
 				{
-					result = "<"
-							+ out
-							+ "> is not a correct or existing expression.";
+					result = control.lbNoCorrectExpr.getText().replace("%", out);
 				} else
 				{
 		// START KGU#101 2015-12-11: Fix #54 (continued)
@@ -2409,9 +2416,9 @@ public class Executor implements Runnable
 			}
 		// START KGU#107 2015-12-13: Enh-/bug #51: Handle empty output instruction
 		}
-		else {
-			str = "(empty line)";
-		}
+//		else {
+//			str = "(empty line)";
+//		}
 		// END KGU#107 2015-12-13
 		if (result.isEmpty())
 		{
@@ -2426,6 +2433,12 @@ public class Executor implements Runnable
 			// START KGU#160 2016-04-12: Enh. #137 - Checkbox for text window output
 			//if (step)
 			this.console.writeln(s);
+			// START KGU#107 2016-05-05: For the message dialog we must show something
+			if (s.isEmpty())
+			{
+				s = "(" + control.lbEmptyLine.getText() + ")";
+			}
+			// END KGU#107 2016-05-05
 			if (isConsoleEnabled)
 			{
 				this.console.setVisible(true);
@@ -2434,14 +2447,14 @@ public class Executor implements Runnable
 			// END KGU#160 2016-04-12
 			{
 				// In step mode, there is no use to offer pausing
-				JOptionPane.showMessageDialog(diagram, s, "Output",
+				JOptionPane.showMessageDialog(diagram, s, control.lbOutput.getText(),
 						JOptionPane.INFORMATION_MESSAGE);
 			}
 			else
 			{
 				// In run mode, give the user a chance to intervene
 				Object[] options = {"OK", "Pause"};	// FIXME: Provide a translation
-				int pressed = JOptionPane.showOptionDialog(diagram, s, "Output",
+				int pressed = JOptionPane.showOptionDialog(diagram, s, control.lbOutput.getText(),
 						JOptionPane.OK_CANCEL_OPTION, JOptionPane.INFORMATION_MESSAGE, null, options, null);
 				if (pressed == 1)
 				{
@@ -2459,6 +2472,7 @@ public class Executor implements Runnable
 	private String tryReturn(String cmd) throws EvalError
 	{
 		String result = "";
+		String header = control.lbReturnedResult.getText();
 		String out = cmd.substring(D7Parser.preReturn.length()).trim();
 		// START KGU#77 (#21) 2015-11-13: We out to allow an empty return
 		//Object n = interpreter.eval(out);
@@ -2482,31 +2496,29 @@ public class Executor implements Runnable
 			{
 				if (resObj == null)
 				{
-					result = "<"
-							+ out
-							+ "> is not a correct or existing expression.";
+					result = control.lbNoCorrectExpr.getText().replace("%", out);
 				// START KGU#133 2016-01-29: Arrays should be presented as scrollable list
 				} else if (resObj instanceof Object[])
 				{
-					showArray((Object[])resObj, "Returned result", !step);
+					showArray((Object[])resObj, header, !step);
 				} else if (step)
 				{
 					// START KGU#160 2016-04-26: Issue #137 - also log the result to the console
-					this.console.writeln("*** Returned result: " + this.prepareValueForDisplay(resObj), Color.CYAN);
+					this.console.writeln("*** " + header + ": " + this.prepareValueForDisplay(resObj), Color.CYAN);
 					// END KGU#160 2016-04-26
 					// START KGU#147 2016-01-29: This "uncoverting" copied from tryOutput() didn't make sense...
 					//String s = unconvert(resObj.toString());
 					//JOptionPane.showMessageDialog(diagram, s,
 					//		"Returned result", JOptionPane.INFORMATION_MESSAGE);
 					JOptionPane.showMessageDialog(diagram, resObj,
-							"Returned result", JOptionPane.INFORMATION_MESSAGE);
+							header, JOptionPane.INFORMATION_MESSAGE);
 					// END KGU#147 2016-01-29					
 				// END KGU#133 2016-01-29
 				} else
 				{
 					// START KGU#84 2015-11-23: Enhancement to give a chance to pause (though of little use here)
 					Object[] options = {"OK", "Pause"};		// FIXME: Provide a translation
-					int pressed = JOptionPane.showOptionDialog(diagram, resObj, "Returned result",
+					int pressed = JOptionPane.showOptionDialog(diagram, resObj, header,
 							JOptionPane.OK_CANCEL_OPTION, JOptionPane.INFORMATION_MESSAGE, null, options, null);
 					if (pressed == 1)
 					{

--- a/src/lu/fisch/structorizer/executor/de.txt
+++ b/src/lu/fisch/structorizer/executor/de.txt
@@ -36,6 +36,7 @@
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data texts
  *      Kay Gürtzig     2016.03.18      Additional message texts for Executor dialog
  *      Kay Gürtzig     2016.04.12      New message text for Control option
+ *      Kay Gürtzig     2016.05.05      KGU#197: Further message texts for Executor dialog
  *
  ******************************************************************************************************
  *
@@ -60,3 +61,11 @@ Control.chkOutputToTextWindow.text=Ausgabe in Fenster
 Control.lbStopRunningProc.text=Diese Aktion ist während der Ausführung eines Diagramms nicht erlaubt.\nLaufende Ausführung abbrechen?
 Control.lbInputValue.text=Bitte Wert für <%> eingeben
 Control.lbInputPaused.text=Ausführung angehalten - der Wert kann in der Variablenanzeige eingetragen werden.
+Control.lbInputCancelled.text=Eingabe abgebrochen
+Control.lbManuallySet.text=*** Manuell gesetzt: %1 <- %2 ***
+Control.lbEmptyLine.text=leere Zeile
+Control.lbNoCorrectExpr.text=<%> ist kein korrekter or existierender Ausdruck.
+Control.lbReturnedResult.text=Zurückgegebenes Resultat
+Control.lbOutput.text=Ausgabe
+Control.lbInput.text=Eingabe
+Control.lbAcknowledge.text=Zum Fortfahren bitte bestätigen.

--- a/src/lu/fisch/structorizer/executor/en.txt
+++ b/src/lu/fisch/structorizer/executor/en.txt
@@ -36,6 +36,7 @@
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data texts
  *      Kay Gürtzig     2016.03.18      Additional message texts for Executor dialog
  *      Kay Gürtzig     2016.04.12      New message text for Control option
+ *      Kay Gürtzig     2016.05.05      KGU#197: Further message texts for Executor dialog
  *
  ******************************************************************************************************
  *
@@ -60,3 +61,11 @@ Control.chkOutputToTextWindow.text=Output to window
 Control.lbStopRunningProc.text=This action is not allowed while a diagram is being executed.\nDo you want to stop the current execution?
 Control.lbInputValue.text=Please enter a value for <%>
 Control.lbInputPaused.text=Execution paused - you may enter the value in the variable display.
+Control.lbInputCancelled.text=Input cancelled
+Control.lbManuallySet.text=*** Manually set: %1 <- %2 ***
+Control.lbEmptyLine.text=empty line
+Control.lbNoCorrectExpr.text=<%> is not a correct or existing expression.
+Control.lbReturnedResult.text=Returned result
+Control.lbOutput.text=Output
+Control.lbInput.text=Input
+Control.lbAcknowledge.text=Please acknowledge to continue.

--- a/src/lu/fisch/structorizer/executor/es.txt
+++ b/src/lu/fisch/structorizer/executor/es.txt
@@ -36,6 +36,7 @@
  *      Kay Gürtzig     2016.03.12      Enh. #124 (KGU#156): Generalized runtime data texts
  *      Kay Gürtzig     2016.03.18      Additional message texts for Executor dialog
  *      Kay Gürtzig     2016.04.12      New message text for Control option
+ *      Kay Gürtzig     2016.05.05      KGU#197: Further message texts for Executor dialog
  *
  ******************************************************************************************************
  *
@@ -60,4 +61,11 @@ Control.chkOutputToTextWindow.text=Salidas a ventana
 Control.lbStopRunningProc.text=Esta acción no está permitida mientras que un diagrama está ejecutido.\n¿Quiere abortar la ejecución?
 Control.lbInputValue.text=Inserta un valor para <%>
 Control.lbInputPaused.text=Ejecución pausando - el valor puede ser insertado en la tabla de variables
-
+Control.lbInputCancelled.text=Entrada suspendida
+Control.lbManuallySet.text=*** Puesto manualmente: %1 <- %2 ***
+Control.lbEmptyLine.text=línea en blanco
+Control.lbNoCorrectExpr.text=<%> no es una expresión correcta o existente.
+Control.lbReturnedResult.text=Resultado devuelto
+Control.lbOutput.text=Salida
+Control.lbInput.text=Entrada
+Control.lbAcknowledge.text=Confirma, por favor, para continuar.

--- a/src/lu/fisch/structorizer/generators/Generator.java
+++ b/src/lu/fisch/structorizer/generators/Generator.java
@@ -97,6 +97,10 @@ public abstract class Generator extends javax.swing.filechooser.FileFilter
 	private String exportCharset = Charset.defaultCharset().name();
 	// END KGU#173 2016-04-04
 	protected StringList code = new StringList();
+	
+	// START KGU#194 2016-05-07: Bugfix #185 - subclasses might need filename access
+	protected String pureFilename = "";
+	// END KGU#194 2016-05-07
 
 	// START KGU#74 2015-11-29: Sound handling of Jumps requires some tracking
 	protected boolean returns = false; // Explicit return instructions occurred?
@@ -867,7 +871,14 @@ public abstract class Generator extends javax.swing.filechooser.FileFilter
 
 	/******** Public Methods *************/
 
+	// START KGU#178 2016-05-07: Enh. #160 - recursion preparation
 	public String generateCode(Root _root, String _indent)
+	{
+		return generateCode(_root, _indent, -1);
+	}
+	
+	protected String generateCode(Root _root, String _indent, int _insertAtLine)
+	// END KGU#178 2016-05-07
 	{
 		// START KGU#74 2015-11-30: General pre-processing phase 1
 		// Code analysis and Header analysis
@@ -951,7 +962,7 @@ public abstract class Generator extends javax.swing.filechooser.FileFilter
 	}
 	// END KGU#74 2015-11-30
 	
-	public void exportCode(Root _root, File _currentDirectory, Frame frame)
+	public void exportCode(Root _root, File _currentDirectory, Frame _frame)
 	{
 		try
 		{
@@ -1014,7 +1025,7 @@ public abstract class Generator extends javax.swing.filechooser.FileFilter
 		dlgSave.addChoosableFileFilter((javax.swing.filechooser.FileFilter) this);
 		dlgSave.setFileFilter((javax.swing.filechooser.FileFilter) this);
 		// END KGU 2016-04-01
-		int result = dlgSave.showSaveDialog(frame);
+		int result = dlgSave.showSaveDialog(_frame);
 
 		/***** file_exists check here!
 		 if(file.exists())
@@ -1067,6 +1078,14 @@ public abstract class Generator extends javax.swing.filechooser.FileFilter
 			}
 			if(writeDown==true)
 			{
+				// START KGU#194 2016-05-07: Bugfix #185 - the subclass may need the filename
+				pureFilename = file.getName();
+				int dotPos = pureFilename.indexOf(".");
+				if (dotPos >= 0)
+				{
+					pureFilename = pureFilename.substring(0, dotPos);
+				}
+				// END KGU#194 2016-05-07
 
 				// START KGU 2016-03-29: Pre-processed match patterns for better identification of complicated keywords
 		    	this.splitKeywords.clear();

--- a/src/lu/fisch/structorizer/generators/PasGenerator.java
+++ b/src/lu/fisch/structorizer/generators/PasGenerator.java
@@ -325,6 +325,13 @@ public class PasGenerator extends Generator
 		}
 		// END KGU#109/KGU#141 2016-01-16
 		
+		// START KGU# 2016-05-05: Bugfix
+		if (transline.startsWith("writeln()"))
+		{
+			transline = "writeln" + transline.substring("writeln()".length());
+		}
+		// END KGU# 2016-05-05
+		
 		return transline.trim(); 
     }
 	
@@ -915,6 +922,7 @@ public class PasGenerator extends Generator
 			StringList _paramNames, StringList _paramTypes, String _resultType)
 	{
         String pr = "program";
+        
         this.procName = _procName;	// Needed for value return mechanisms
 
         insertComment(_root, _indent);
@@ -922,6 +930,15 @@ public class PasGenerator extends Generator
         
         String signature = _root.getMethodName();
         if (!_root.isProgram) {
+        	// START KGU#194 2016-05-07: Bugfix #185 - create a unit context
+        	//if (subInsertPos < 0)
+        	//{
+        	code.add(_indent + "UNIT " + pureFilename + ";");
+	        code.add(_indent);
+        	code.add(_indent + "INTERFACE");
+	        code.add(_indent);
+        	//}
+        	// END KGU#194 2016-05-07
         	pr = "function";
 			// Compose the function header
         	signature += "(";
@@ -940,6 +957,17 @@ public class PasGenerator extends Generator
 			{
 				pr = "procedure";
 			}
+        	// START KGU#194 2016-05-07: Bugfix #185 - create a unit context
+        	//if (subInsertPos < 0)
+        	//{
+	        code.add(_indent + pr + " " + signature + ";");
+	        code.add(_indent);
+        	code.add(_indent + "IMPLEMENTATION");
+	        code.add(_indent);
+        	insertComment("TODO: Repeat the parameter and result type specifications of the INTERFACE section!", _indent);
+        	//}
+        	// END KGU#194 2016-05-07
+			
         }
         code.add(_indent + pr + " " + signature + ";");
         
@@ -1000,6 +1028,20 @@ public class PasGenerator extends Generator
 	@Override
 	protected void generateFooter(Root _root, String _indent)
 	{
+    	// START KGU#194 2016-05-07: Bugfix #185 - create a unit context
+        if (!_root.isProgram) {
+        	//if (subInsertPos < 0)
+        	//{
+        	code.add(_indent);
+        	code.add(_indent + "end;");
+        	code.add(_indent);
+        	code.add(_indent + "BEGIN");
+    		code.add(_indent + "END.");
+        	//}
+        }
+        else
+    	// END KGU#194 2016-05-07
+		
 		code.add(_indent + "end.");
 	}
 	// END KGU#74 2015-11-30

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -2007,6 +2007,9 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		//System.out.println("Arranger button pressed!");
 		Arranger arr = Arranger.getInstance();
 		arr.addToPool(root, NSDControl.getFrame());
+		// START KGU#202 2016-07-03: Localization of Arranger
+		arr.setLangLocal(this.getLang());
+		//BEND KGU#202 2016-07-03
 		arr.setVisible(true);
 		isArrangerOpen = true;	// Gives the Executor a hint where to find a subroutine pool
 	}

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -9,14 +9,14 @@ Legend:
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 <Foo>   -->     idea AND coding done by Foo
 
-Current development version: 3.24-12 (2016.06.??)
+Current development version: 3.24-12 (2016.07.03)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]
-- 01: Enh. #124: Generalized runtime data visualisation <Kay Gürtzig>
+- 01: Enh. #124: Generalized runtime data visualization <Kay Gürtzig>
 - 01: Arranger now adopts current directory from first arranged diagram <Kay Gürtzig>
 - 02: Bugfix #131: User activities during execution could compromise Executor <Kay Gürtzig>
 - 02: Bugfix #132: Stale Structorizer references in Arranger caused trouble <Kay Gürtzig>
 - 02: Enh. #133: Execution Call stack may now be inspected in paused state <Kay Gürtzig>
-- 02: Enh. KGU#89: Executor: Extended language localisation support <Kay Gürtzig>
+- 02: Enh. KGU#89: Executor: Extended language localization support <Kay Gürtzig>
 - 03: Enh. #84/#135: For-In loops now consistently supported [R. Schmidt]<Kay Gürtzig>
 - 03: Issue #79/#152: Requested Java version corrected (1.6 --> 1.8) <Kay Gürtzig>
 - 04: Bugfix #96/#135: On BASH export conditions now put into [[ ]] [Rolf Schmidt]
@@ -61,6 +61,8 @@ Current development version: 3.24-12 (2016.06.??)
 - 12: Issue #185: Pascal import now copes with multiple routines per file. <Kay Gürtzig> 
 - 12: Executor: Enhanced language support (EN/DE/ES) and minor bugfixing <Kay Gürtzig>
 - 12: Arranger now offers saving before removing "dirty" diagrams <Kay Gürtzig>
+- 12: Enh. #62: Arranger may now save arrangements in a portable way <Kay Gürtzig>
+- 12: Arranger: Partial language support (EN/DE/ES) introduced <Kay Gürtzig>
 
 Version: 3.24 (2016.03.14)
 - 01: Bugfix #50 - added return types to signature for function export in Pascal [lhoreman]

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -9,7 +9,7 @@ Legend:
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 <Foo>   -->     idea AND coding done by Foo
 
-Current development version: 3.24-11 (2016.05.03)
+Current development version: 3.24-12 (2016.05.??)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]
 - 01: Enh. #124: Generalized runtime data visualisation <Kay Gürtzig>
 - 01: Arranger now adopts current directory from first arranged diagram <Kay Gürtzig>
@@ -56,6 +56,11 @@ Current development version: 3.24-11 (2016.05.03)
 - 11: Enh. #179: Code generation and parsing in batch mode [Rolf Schmidt] <Kay Gürtzig>
 - 11: Bugfix #181: Pascal export didn't convert all string delimiters <Kay Gürtzig>
 - 11: Bugfix #184: Diagram imported from Pascal now enables save button <Kay Gürtzig>
+- 12: Several minor bugfixes in Pascal export and import <Kay Gürtzig>
+- 12: Issue #185: Pascal export of functions/procedures now as units. <Kay Gürtzig>
+- 12: Issue #185: Pascal import now copes with multiple routines per file. <Kay Gürtzig> 
+- 12: Executor: Enhanced language support (EN/DE/ES) and minor bugfixing <Kay Gürtzig>
+- 12: Arranger now offers saving before removing "dirty" diagrams <Kay Gürtzig>
 
 Version: 3.24 (2016.03.14)
 - 01: Bugfix #50 - added return types to signature for function export in Pascal [lhoreman]

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -9,7 +9,7 @@ Legend:
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 <Foo>   -->     idea AND coding done by Foo
 
-Current development version: 3.24-12 (2016.05.??)
+Current development version: 3.24-12 (2016.06.??)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]
 - 01: Enh. #124: Generalized runtime data visualisation <Kay Gürtzig>
 - 01: Arranger now adopts current directory from first arranged diagram <Kay Gürtzig>

--- a/src/lu/fisch/structorizer/io/ArrZipFilter.java
+++ b/src/lu/fisch/structorizer/io/ArrZipFilter.java
@@ -1,0 +1,91 @@
+/*
+    Structorizer
+    A little tool which you can use to create Nassi-Schneiderman Diagrams (NSD)
+
+    Copyright (C) 2009  Bob Fisch
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or any
+    later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package lu.fisch.structorizer.io;
+
+/******************************************************************************************************
+ *
+ *      Author:         Kay Gürtzig
+ *
+ *      Description:    Input filter for Arranger Zip files. They contain nsd files and an arr file
+ *
+ ******************************************************************************************************
+ *
+ *      Revision List
+ *
+ *      Author          Date			Description
+ *      ------          ----            -----------
+ *      Kay Gürtzig     2016.06.29      First Issue
+ *
+ ******************************************************************************************************
+ *
+ *      Comment:		/
+ *
+ ******************************************************************************************************///
+
+import java.io.File;
+import javax.swing.filechooser.*;
+
+public class ArrZipFilter extends FileFilter {
+
+	public static boolean isArr(String _filename)
+	{
+		return (getExtension(_filename).equals("arrz"));
+	}
+
+	public static String getExtension(String s) 
+	{
+		String ext = null;
+		int i = s.lastIndexOf('.');
+
+		if (i > 0 &&  i < s.length() - 1) 
+		{
+			ext = s.substring(i+1).toLowerCase();
+		}
+		return ext;
+	}
+
+	public static String getExtension(File f) 
+	{
+		return getExtension(f.getName());
+	}
+
+	public String getDescription() 
+	{
+		return "Portable Arranger Zip Files";
+	}
+
+	public boolean accept(File f) 
+	{
+		if (f.isDirectory()) 
+		{
+			return true;
+		}
+
+		String extension = getExtension(f);
+		if (extension != null) 
+		{
+			return isArr(f.getName());
+		}
+
+		return false;
+	}
+
+}

--- a/src/lu/fisch/structorizer/parsers/D7Parser.java
+++ b/src/lu/fisch/structorizer/parsers/D7Parser.java
@@ -41,6 +41,8 @@ package lu.fisch.structorizer.parsers;
  *      Kay Gürtzig     2016-04-04      KGU#165: Default for ignoreCase changed to true
  *      Kay Gürtzig     2016-04-30      Issue #182 (KGU#191): More information on error exit in parse()
  *      Kay Gürtzig     2016-05-02      Issue #184 / Enh. #10: Flaws in FOR loop import (KGU#192)
+ *      Kay Gürtzig     2016-05-04      KGU#194: Bugfix - parse() now with Charset argument
+ *      Kay Gürtzig     2016-05-05/09   Issue #185: Import now copes with units and multiple routines per file
  *
  ******************************************************************************************************
  *
@@ -59,6 +61,9 @@ package lu.fisch.structorizer.parsers;
 import java.io.*;
 import java.nio.*;
 import java.nio.charset.*;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Vector;
 
 import goldengine.java.*;
 import lu.fisch.utils.*;
@@ -109,14 +114,22 @@ public class D7Parser implements GPMessageConstants
 
 	private String compiledGrammar = null;
 	Root root = null;
+	// START KGU#194 2016-05-08: Bugfix #185
+	// We may obtain a collection of Roots (unit or program with subroutines)!
+	private List<Root> subRoots = new LinkedList<Root>();
+	// END KGU#194 2016-05-08
 	
 	public String error = new String();
 	
 	GOLDParser parser = null;
 	
+	// START KGU#194 2016-05-08: Bugfix #185 - if being a unit we must retain its name
+	private String unitName = null;
+	// END KGU#194 2016-05-08
+	
 	public D7Parser(String _compiledGrammar)
 	{
-		compiledGrammar=_compiledGrammar;
+		compiledGrammar = _compiledGrammar;
 		// create new parser
 		parser = new GOLDParser();
 		parser.setTrimReductions(true);
@@ -166,7 +179,30 @@ public class D7Parser implements GPMessageConstants
 		return result;	
 	}
 	
+	// START KGU#193 2016-05-04
+	/**
+	 * Parses the Pascal source code from file _textToParse and returns an equivalent
+	 * structogram.
+	 * Field `error' will either contain an empty string or an error message afterwards.
+	 * For backward compatibility reasons, character encoding ISO-8859-1 is assumed.
+	 * @param _textToParse - file name of the Pascal source.
+	 * @return The composed diagram (if parsing was successful, otherwise field error will contain an error description) 
+	 */
 	public Root parse(String _textToParse)
+	{
+		return parse(_textToParse, "ISO-8859-1").get(0);
+	}
+
+	/**
+	 * Parses the Pascal source code from file _textToParse, which is supposed to be encoded
+	 * with the charset _encoding, and returns an equivalent structogram.
+	 * Field `error' will either contain an empty string or an error message afterwards.
+	 * @param _textToParse - file name of the Pascal source.
+	 * @param _encoding - name of the charset to be used for decoding
+	 * @return The composed diagram (if parsing was successful, otherwise field error will contain an error description) 
+	 */
+	public List<Root> parse(String _textToParse, String _encoding)
+	// END KGU#193 2016-05-04
 	{
 		// create new root
 		root = new Root();
@@ -176,29 +212,37 @@ public class D7Parser implements GPMessageConstants
 		try
 		{
 			DataInputStream in = new DataInputStream(new FileInputStream(_textToParse));
-			BufferedReader br = new BufferedReader(new InputStreamReader(in, "ISO-8859-1"));
+			// START KGU#193 2016-05-04
+			BufferedReader br = new BufferedReader(new InputStreamReader(in, _encoding));
+			// END KGU#193 2016-05-04
 			String strLine;
 			String pasCode = new String();
 			//Read File Line By Line
 			while ((strLine = br.readLine()) != null)   
 			{
 				// add no ending because of comment filter
-				pasCode+=strLine+"\u2190";
+				pasCode += strLine+"\u2190";
 				//pasCode+=strLine+"\n";
 			}
 			//Close the input stream
 			in.close();
 			
-			// filter out comments
+			// filter out comments (KGU: Why? The GOLDParser can do it itself)
 			Regex r = new Regex("(.*?)[(][*](.*?)[*][)](.*?)","$1$3"); 
 			pasCode=r.replaceAll(pasCode);
 			r = new Regex("(.*?)[{](.*?)[}](.*?)","$1$3"); 
-			pasCode=r.replaceAll(pasCode);
+			pasCode = r.replaceAll(pasCode);
 			
+			// START KGU#195 2016-05-04: Issue #185 - Workaround for mere subroutines
+			pasCode = embedSubroutineDeclaration(pasCode);
+			// END KGU#195 2016-05-04
+						
 			// reset correct endings
 			r = new Regex("(.*?)[\u2190](.*?)","$1\n$2"); 
-			pasCode=r.replaceAll(pasCode);
-						
+			pasCode = r.replaceAll(pasCode);
+			
+			//System.out.println(pasCode);
+			
 			// trim and save as new file
 			OutputStreamWriter ow = new OutputStreamWriter(new FileOutputStream(_textToParse+".structorizer"), "ISO-8859-1");
 			ow.write(filterNonAscii(pasCode.trim()+"\n"));
@@ -344,12 +388,55 @@ public class D7Parser implements GPMessageConstants
 		//remove the temporary file
 		(new File(_textToParse+".structorizer")).delete();
 		
-		return root;
+		// START KGU#194 2016-05-08: Bugfix #185 - face an empty program or unit vessel
+		//return root;
+		if (subRoots.isEmpty() || root.children.getSize() > 0)
+		{
+			subRoots.add(0, root);
+		}
+		return subRoots;
+		// END KGU#194 2016-05-08
 	}
 	
+	// START KGU#195 2016-05-04: Issue #185 - Workaround for mere subroutines
+	private String embedSubroutineDeclaration(String _pasCode)
+	{
+		// Find the first non-empty line where line ends are encoded as "\u2190"
+		boolean headerFound = false;
+		int pos = -1;
+		int lineEnd = -1;
+		while (!headerFound && (lineEnd = _pasCode.indexOf("\u2190", pos+1)) >= 0)
+		{
+			String line = _pasCode.substring(pos+1, lineEnd).toLowerCase();
+			pos = lineEnd;
+			// If the file contains a program or unit then we leave it as is
+			// for the moment...
+			if (line.startsWith("program") || line.startsWith("unit"))
+			{
+				headerFound = true;
+			}
+			else if (line.startsWith("function") ||
+					 line.startsWith("procedure"))
+			{
+				// embed the declaration in a dummy program definition as
+				// workaround
+				headerFound = true;
+				_pasCode = "program dummy;" + "\u2190"
+						+ _pasCode + "\u2190"
+						+ "begin" + "\u2190"
+						+ "end." + "\u2190";
+			}
+		}
+		return _pasCode;
+	}
+	// END KGU#195 2016-05-04
+
 	private void DrawNSD(Reduction _reduction)
 	{
 		root.isProgram=true;
+		// START KGU#194 2016-05-08: Bugfix #185
+		unitName = null;
+		// END KGU#194 2016-05-08
 		DrawNSD_R(_reduction, root.children);
 	}
 	
@@ -360,6 +447,7 @@ public class D7Parser implements GPMessageConstants
 		if (_reduction.getTokenCount()>0)
 		{
 			String ruleName = _reduction.getParentRule().name();
+			//System.out.println(ruleName);
 			if ( 
 				ruleName.equals("<RefId>")
 				||
@@ -381,9 +469,46 @@ public class D7Parser implements GPMessageConstants
 					 ruleName.equals("<VarSection>")
 					 ||
 					 ruleName.equals("<ConstSection>")
+					 // START KGU#194 2016-05-08: Bugfix #185
+					 // UNIT Interface section can be ignored, all contained routines
+					 // must be converted from the implementation section
+					 ||
+					 ruleName.equals("<InterfaceSection>")
+					 ||
+					 ruleName.equals("<InitSection>")
+					 // END KGU#194 2016-05-08
 					 )
 			{
 			}
+			// START KGU#194 2016-05-08: Bugfix #185 - we must handle unit headers
+			else if (
+					ruleName.equals("<UnitHeader>")
+					)
+			{
+				unitName = getContent_R((Reduction) _reduction.getToken(1).getData(), "");
+			}
+			else if (
+					ruleName.equals("<ProcedureDecl>")
+					||
+					ruleName.equals("<FunctionDecl>")
+					||
+					ruleName.equals("<MethodDecl>")
+					)
+			{
+				Root prevRoot = root;	// Push the original root
+				root = new Root();	// Prepare a new root for the subroutine
+				subRoots.add(root);
+				for (int i=0; i < _reduction.getTokenCount(); i++)
+				{
+					if (_reduction.getToken(i).getKind() == SymbolTypeConstants.symbolTypeNonterminal)
+					{
+						DrawNSD_R((Reduction) _reduction.getToken(i).getData(), root.children);
+					}
+				}
+				// Restore the original root
+				root = prevRoot;
+			}
+			// END KGU#194 2016-05-08
 			else if (
 					 ruleName.equals("<ProgHeader>")
 					 )
@@ -396,26 +521,32 @@ public class D7Parser implements GPMessageConstants
 					 ruleName.equals("<ProcHeading>")
 					 )
 			{
-				content=new String();
-				content=getContent_R((Reduction) _reduction.getToken(1).getData(),content);
+				content = new String();
+				content = getContent_R((Reduction) _reduction.getToken(1).getData(),content);
 				
 				Reduction secReduc = (Reduction) _reduction.getToken(2).getData();
 				if (secReduc.getTokenCount()!=0)
 				{
-					content=getContent_R(secReduc,content);
+					content = getContent_R(secReduc, content);
 				}
 				
 				content = BString.replaceInsensitive(content,";","; ");
 				content = BString.replaceInsensitive(content,";  ","; ");
 				root.setText(updateContent(content));
 				root.isProgram=false;
+				// START KGU#194 2016-05-08: Bugfix #185 - be aware of unit context
+				if (unitName != null)
+				{
+					root.setComment("(UNIT " + unitName + ")");
+				}
+				// END KGU#194 2016-05-08
 			}
 			else if (
 					 ruleName.equals("<FuncHeading>")
 					 )
 			{
-				content=new String();
-				content=getContent_R((Reduction) _reduction.getToken(1).getData(),content);
+				content = new String();
+				content = getContent_R((Reduction) _reduction.getToken(1).getData(),content);
 				
 				Reduction secReduc = (Reduction) _reduction.getToken(2).getData();
 				if (secReduc.getTokenCount()!=0)
@@ -426,33 +557,39 @@ public class D7Parser implements GPMessageConstants
 				secReduc = (Reduction) _reduction.getToken(4).getData();
 				if (secReduc.getTokenCount()!=0)
 				{
-					content+=": ";
-					content=getContent_R(secReduc,content);
+					content += ": ";
+					content = getContent_R(secReduc, content);
 				}
 				
-				content = BString.replaceInsensitive(content,";","; ");
-				content = BString.replaceInsensitive(content,";  ","; ");
+				content = BString.replaceInsensitive(content, ";", "; ");
+				content = BString.replaceInsensitive(content, ";  ", "; ");
 				root.setText(updateContent(content));
-				root.isProgram=false;
+				root.isProgram = false;
+				// START KGU#194 2016-05-08: Bugfix #185 - be aware of unit context
+				if (unitName != null)
+				{
+					root.setComment("(UNIT " + unitName + ")");
+				}
+				// END KGU#194 2016-05-08
 			}
 			else if (
 					 ruleName.equals("<WhileStatement>")
 					 )
 			{
-				content=new String();
-				content=getContent_R((Reduction) _reduction.getToken(1).getData(),content);
+				content = new String();
+				content = getContent_R((Reduction) _reduction.getToken(1).getData(), content);
 				While ele = new While(preWhile+updateContent(content)+postWhile);
 				_parentNode.addElement(ele);
 				
 				Reduction secReduc = (Reduction) _reduction.getToken(3).getData();
-				DrawNSD_R(secReduc,ele.q);
+				DrawNSD_R(secReduc, ele.q);
 			}
 			else if (
 					 ruleName.equals("<RepeatStatement>")
 					 )
 			{
-				content=new String();
-				content=getContent_R((Reduction) _reduction.getToken(3).getData(),content);
+				content = new String();
+				content = getContent_R((Reduction)_reduction.getToken(3).getData(), content);
 				Repeat ele = new Repeat(preRepeat+updateContent(content)+postRepeat);
 				_parentNode.addElement(ele);
 				
@@ -463,14 +600,14 @@ public class D7Parser implements GPMessageConstants
 					 ruleName.equals("<ForStatement>")
 					 )
 			{
-				content=new String();
-				content=getContent_R((Reduction) _reduction.getToken(1).getData(),content);
-				content+=":=";
-				content=getContent_R((Reduction) _reduction.getToken(3).getData(),content);
-				content+=" ";
-				content+=postFor;
-				content+=" ";
-				content=getContent_R((Reduction) _reduction.getToken(5).getData(),content);
+				content = new String();
+				content = getContent_R((Reduction) _reduction.getToken(1).getData(),content);
+				content += ":=";
+				content = getContent_R((Reduction) _reduction.getToken(3).getData(),content);
+				content += " ";
+				content += postFor;
+				content += " ";
+				content = getContent_R((Reduction) _reduction.getToken(5).getData(),content);
 				// START KGU#3 2016-05-02: Enh. #10 Token 4 contains the information whether it's to or downto
 				if (getContent_R((Reduction) _reduction.getToken(4).getData(), "").equals("downto"))
 				{
@@ -485,16 +622,16 @@ public class D7Parser implements GPMessageConstants
 				
 				// Get and convert the body
 				Reduction secReduc = (Reduction) _reduction.getToken(7).getData();
-				DrawNSD_R(secReduc,ele.q);
+				DrawNSD_R(secReduc, ele.q);
 			}
 			else if (
 					 ruleName.equals("<IfStatement>")
 					 )
 			{
-				content=new String();
-				content=getContent_R((Reduction) _reduction.getToken(1).getData(),content);
+				content = new String();
+				content = getContent_R((Reduction) _reduction.getToken(1).getData(),content);
 				
-				Alternative ele = new Alternative(preAlt+updateContent(content)+postAlt);
+				Alternative ele = new Alternative(preAlt + updateContent(content) + postAlt);
 				_parentNode.addElement(ele);
 				
 				Reduction secReduc = (Reduction) _reduction.getToken(3).getData();
@@ -509,14 +646,14 @@ public class D7Parser implements GPMessageConstants
 					 ruleName.equals("<CaseSelector>")
 					 )
 			{
-				content=new String();
-				content=getContent_R((Reduction) _reduction.getToken(0).getData(),content);
+				content = new String();
+				content = getContent_R((Reduction) _reduction.getToken(0).getData(),content);
 				
 				// sich am parent (CASE) dat nächst fräit Element
 				boolean found = false;
-				for(int i=0;i<((Case) _parentNode.parent).getText().count();i++)
+				for(int i=0; i<((Case) _parentNode.parent).getText().count(); i++)
 				{
-					if(((Case) _parentNode.parent).getText().get(i).equals("??") && found==false)
+					if (((Case) _parentNode.parent).getText().get(i).equals("??") && found==false)
 					{
 						((Case) _parentNode.parent).getText().set(i,content);
 						found=true;
@@ -547,18 +684,18 @@ public class D7Parser implements GPMessageConstants
 					 ruleName.equals("<CaseStatement>")
 					 )
 			{
-				content=new String();
-				content=preCase+getContent_R((Reduction) _reduction.getToken(1).getData(),content)+postCase;
+				content = new String();
+				content = preCase+getContent_R((Reduction) _reduction.getToken(1).getData(),content)+postCase;
 				// am content steet elo hei den "test" dran
 				
 				// Wéivill Elementer sinn am CASE dran?
 				Reduction sr = (Reduction) _reduction.getToken(3).getData();
-				int j=0;
+				int j = 0;
 				//System.out.println(sr.getParentRule().getText());  // <<<<<<<
-				while(sr.getParentRule().name().equals("<CaseList>"))
+				while (sr.getParentRule().name().equals("<CaseList>"))
 				{
 					  j++;
-					  content+="\n??";
+					  content += "\n??";
 					  if (sr.getTokenCount()>=1)
 					  {
 						sr = (Reduction) sr.getToken(0).getData();
@@ -569,10 +706,10 @@ public class D7Parser implements GPMessageConstants
 					  }
 				}
 				
-				if ( j>0) 
+				if (j>0) 
 				{
 					j++;
-					content+="\nelse";
+					content += "\nelse";
 				}
 
 				Case ele = new Case(updateContent(content));
@@ -584,12 +721,12 @@ public class D7Parser implements GPMessageConstants
 				DrawNSD_R(secReduc,(Subqueue) ele.qs.get(0));
 				// den "otherwise"
 				secReduc = (Reduction) _reduction.getToken(4).getData();
-				DrawNSD_R(secReduc,(Subqueue) ele.qs.get(j-1));
+				DrawNSD_R(secReduc, (Subqueue) ele.qs.get(j-1));
 				
 				// cut off else, if possible
 				if (((Subqueue) ele.qs.get(j-1)).getSize()==0)
 				{
-					ele.getText().set(ele.getText().count()-1,"%");
+					ele.getText().set(ele.getText().count()-1, "%");
 				}
 
 				/*
@@ -627,7 +764,7 @@ public class D7Parser implements GPMessageConstants
 			{
 				if (_reduction.getTokenCount()>0)
 				{
-					for(int i=0;i<_reduction.getTokenCount();i++)
+					for(int i=0; i<_reduction.getTokenCount(); i++)
 					{
 						if (_reduction.getToken(i).getKind()==SymbolTypeConstants.symbolTypeNonterminal)
 						{
@@ -654,14 +791,14 @@ public class D7Parser implements GPMessageConstants
 		r = new Regex(BString.breakup("readln")+"(.*?)",input+" $1"); _content=r.replaceAll(_content);
 		r = new Regex(BString.breakup("read")+"(.*?)",input+" $1"); _content=r.replaceAll(_content);*/
 
-		_content = _content.replaceAll(BString.breakup("write")+"[((](.*?)[))]",output+" $1");
-		_content = _content.replaceAll(BString.breakup("writeln")+"[((](.*?)[))]",output+" $1");
-		_content = _content.replaceAll(BString.breakup("writeln")+"(.*?)",output+" $1");
-		_content = _content.replaceAll(BString.breakup("write")+"(.*?)",output+" $1");
-		_content = _content.replaceAll(BString.breakup("read")+"[((](.*?)[))]",input+" $1");
-		_content = _content.replaceAll(BString.breakup("readln")+"[((](.*?)[))]",input+" $1");
-		_content = _content.replaceAll(BString.breakup("readln")+"(.*?)",input+" $1");
-		_content = _content.replaceAll(BString.breakup("read")+"(.*?)",input+" $1");
+		_content = _content.replaceAll(BString.breakup("write")+"[((](.*?)[))]", output+" $1");
+		_content = _content.replaceAll(BString.breakup("writeln")+"[((](.*?)[))]", output+" $1");
+		_content = _content.replaceAll(BString.breakup("writeln")+"(.*?)", output+" $1");
+		_content = _content.replaceAll(BString.breakup("write")+"(.*?)", output+" $1");
+		_content = _content.replaceAll(BString.breakup("read")+"[((](.*?)[))]", input+" $1");
+		_content = _content.replaceAll(BString.breakup("readln")+"[((](.*?)[))]", input+" $1");
+		_content = _content.replaceAll(BString.breakup("readln")+"(.*?)", input+" $1");
+		_content = _content.replaceAll(BString.breakup("read")+"(.*?)", input+" $1");
 		
 		//System.out.println(_content);
 		
@@ -670,25 +807,28 @@ public class D7Parser implements GPMessageConstants
 		*/
 		
 		//_content = BString.replace(_content, ":="," \u2190 ");
-		_content = BString.replace(_content, ":="," <- ");
+		_content = BString.replace(_content, ":=", " <- ");
 
 		return _content.trim();
 	}
 	
 	private String getContent_R(Reduction _reduction, String _content)
 	{
-		if (_reduction.getTokenCount()>0)
-		{
-			for(int i=0;i<_reduction.getTokenCount();i++)
+//		if (_reduction.getTokenCount()>0)
+//		{
+			for(int i=0; i<_reduction.getTokenCount(); i++)
 			{
 				switch (_reduction.getToken(i).getKind()) 
 				{
 					case SymbolTypeConstants.symbolTypeNonterminal:
-						_content=getContent_R((Reduction) _reduction.getToken(i).getData(), _content);	
+						_content = getContent_R((Reduction) _reduction.getToken(i).getData(), _content);	
 						break;
 					case SymbolTypeConstants.symbolTypeTerminal:
 						{
 							String tokenData = (String) _reduction.getToken(i).getData();
+							// START KGU 2016-05-08: Avoid keyword concatenation
+							boolean tokenIsId = !tokenData.isEmpty() && Character.isJavaIdentifierStart(tokenData.charAt(0));
+							// END KGU 2016-05-08
 							if (tokenData.trim().equalsIgnoreCase("mod") ||
 									// START KGU#192 2016-05-02: There are more operators to be considered...
 									tokenData.trim().equalsIgnoreCase("shl") ||
@@ -697,7 +837,22 @@ public class D7Parser implements GPMessageConstants
 									tokenData.trim().equalsIgnoreCase("div"))
 							{
 								_content += " " + tokenData + " ";
+								// START KGU 2016-05-08: Avoid keyword concatenation
+								tokenIsId = false;
+								// END KGU 2016-05-08
 							}
+							// START KGU 2016-05-08: Avoid keyword concatenation
+							else if (
+									tokenIsId
+									&&
+									!_content.isEmpty()
+									&&
+									Character.isJavaIdentifierPart(_content.charAt(_content.length()-1))
+									)
+							{
+								_content += " " + tokenData;
+							}
+							// END KGU 2016-05-08
 							else
 							{
 								_content += tokenData;
@@ -708,12 +863,12 @@ public class D7Parser implements GPMessageConstants
 						break;
 				}
 			}
-		}
-		else
-		{
-			// ?
-			// _content:=_content+trim(R.ParentRule.Text)
-		}
+//		}
+//		else
+//		{
+//			// ?
+//			// _content:=_content+trim(R.ParentRule.Text)
+//		}
 		
 		_content = BString.replaceInsensitive(_content,")and(",") and (");
 		_content = BString.replaceInsensitive(_content,")or(",") or (");
@@ -831,5 +986,5 @@ public class D7Parser implements GPMessageConstants
 		return keywords;
 	}
 	// END KGU#163 2016-03-25
-
+	
 }


### PR DESCRIPTION
- Several minor bugfixes in Pascal export and import
- Issue #185: Pascal export of functions/procedures now as units.
- Issue #185: Pascal import now copes with multiple routines per file.
- Executor: Enhanced language support (EN/DE/ES) and minor bugfixing
- Arranger now offers saving before removing "dirty" diagrams
- Enh. #62: Arranger may now save arrangements in a portable way (zip files).
- Arranger: Partial language support (EN/DE/ES) introduced

PLEASE update the structorizer.bat on this occasion!
[Structorizer.bat.zip](https://github.com/fesch/Structorizer.Desktop/files/345277/Structorizer.bat.zip)
