### PR TITLE
Bugfix3.25 - Version 3.25-07 candidate

### DIFF
--- a/src/lu/fisch/structorizer/arranger/Arranger.java
+++ b/src/lu/fisch/structorizer/arranger/Arranger.java
@@ -52,6 +52,7 @@ package lu.fisch.structorizer.arranger;
  *      Kay Gürtzig     2016.07.03  Dialog message translation mechanism added (KGU#203).
  *      Kay Gürtzig     2016.09.26  Enh. #253: New public method getAllRoots() added.
  *      Kay Gürtzig     2016.11.01  Enh. #81: Scalability of the Icons ensured
+ *      Kay Gürtzig     2016.11.15  Enh. #290: New opportunity to load arrangements from Structorizer
  *
  ******************************************************************************************************
  *
@@ -161,6 +162,21 @@ public class Arranger extends LangFrame implements WindowListener, KeyListener, 
         }
     }
     // END KGU#2 2015-11-19
+
+    // START KGU#289 2016-11-15: Enh. #290 (Arrangement files oadable from Structorizer)
+    /**
+     * Has the file specified by arrFilename (may be an .arr or an .arrz file) loaded as
+     * arrangement.
+     * 
+     * @param frame - potentially an associable Mainform (Structorizer)
+     * @param filename - Name of the file to be loaded as arrangement
+     * @return error message if something went wrong
+     */
+    public String loadArrangement(Mainform form, String arrFilename)
+    {
+    	return surface.loadArrFile(form, arrFilename);
+    }
+    // END KGU#259 2016-11-15
 
     // START KGU#155 2016-03-08: Bugfix #97 extension
     /**
@@ -617,5 +633,5 @@ public class Arranger extends LangFrame implements WindowListener, KeyListener, 
         surface.repaint();
     }
 	// END KGU#156 2016-03-10
-
+    
 }

--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -757,10 +757,26 @@ public abstract class Element {
 	 */
 	public boolean isExecuted()
 	{
-		return this.executed || this.waited;
+		// START KGU#143 2016-11-17: Issue #114 refinement
+		//return this.executed || this.waited;
+		return this.isExecuted(true);
+		// END KGU#143 2016-11-17
 	}
 	// END KGU#143 2016-01-22
 	
+    // START KGU#143 2016-11-17: Bugfix #114 - we need a method avoiding cyclic recursion
+	/**
+	 * Checks execution involvement.
+	 * @param checkParent - whether the waiting status of the owning Subqueue is relevant
+	 * @return true iff this or some substructure of this is currently executed. 
+	 */
+	public boolean isExecuted(boolean checkParent)
+	{
+		return this.executed || this.waited
+				|| checkParent && this.parent != null && this.parent.getClass().getSimpleName().equals("Subqueue") && this.parent.isExecuted();
+	}
+	// END KGU#143 2016-11-17
+
 	// START KGU#156 2016-03-11: Enh. #124 - We need a consistent execution step counting
 	/**
 	 * Resets all element execution counts and the derived maximum execution count as well

--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -177,7 +177,7 @@ import javax.swing.ImageIcon;
 
 public abstract class Element {
 	// Program CONSTANTS
-	public static String E_VERSION = "3.25-06";
+	public static String E_VERSION = "3.25-07";
 	public static String E_THANKS =
 	"Developed and maintained by\n"+
 	" - Robert Fisch <robert.fisch@education.lu>\n"+

--- a/src/lu/fisch/structorizer/elements/Subqueue.java
+++ b/src/lu/fisch/structorizer/elements/Subqueue.java
@@ -50,6 +50,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.07.06      Bugfix: changes of the element set now force drawing info invalidation
  *      Kay Gürtzig     2016.07.07      Enh. #185 + #188: Mechanism to convert Instructions to Calls
  *      Kay Gürtzig     2016.10.13      Enh. #277: setDisabled() added.
+ *      Kay Gürtzig     2016.11.17      Bugfix #114: isExecuted() revised (signature too)
  *
  ******************************************************************************************************
  *
@@ -463,14 +464,22 @@ public class Subqueue extends Element implements IElementSequence {
 	 * @see lu.fisch.structorizer.elements.Element#isExecuted()
 	 */
 	@Override
-	public boolean isExecuted()
+	public boolean isExecuted(boolean ignored)
 	{
 		boolean involved = false;
-		for (int index = 0; !involved && index < this.getSize(); index++)
+		// START KGU#143 2016-11-17: Issue #114 - If the parent isn't in waited state then there may not be execution here
+		if (parent == null || parent.waited)
 		{
-			if (children.get(index).isExecuted())
+		// END KGU#143 2016-11-17
+			for (int index = 0; !involved && index < this.getSize(); index++)
 			{
-				involved = true;
+				// START KGU#143 2016-11-17: Issue #114 - Don't risk cyclic recursion!
+				//if (children.get(index).isExecuted())
+				if (children.get(index).isExecuted(false))
+				// END KGU#143 2016-11-17
+				{
+					involved = true;
+				}
 			}
 		}
 		return involved;

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -104,6 +104,7 @@ package lu.fisch.structorizer.executor;
  *      Kay Gürtzig     2016.10.16      Enh. #273: Input strings "true" and "false" now accepted as boolean values
  *                                      Bugfix #276: Raw string conversion and string display mended, undue replacements
  *                                      of ' into " in method convert() eliminated
+ *      Kay Gürtzig     2016.11.19      Issue #269: Scrolling problem eventually solved. 
  *
  ******************************************************************************************************
  *
@@ -1871,11 +1872,13 @@ public class Executor implements Runnable
 		//boolean atBreakpoint = element.isBreakpoint();
 		boolean atBreakpoint = element.triggersBreakNow();
 		// END KGU#213 2016-08-01
+		// START KGU#276 2016-11-19: Issue #267: in paused mode we should move the focus to the current element
+		if (delay > 0 || step || atBreakpoint) {
+			diagram.redraw(element);
+		}
+		// END KGU#276 2016-11-19
 		if (atBreakpoint) {
 			control.setButtonsForPause();
-			// START KGU#276 2016-10-09: Issue #267: in paused mode we should move the focus to the current element
-			diagram.redraw(element);
-			// END KGU#276 2016-10-09
 
 			this.setPaus(true);
 		}
@@ -1894,17 +1897,17 @@ public class Executor implements Runnable
 		// END KGU#277 2016-10-13
 		
 		element.executed = true;
-		// START KGU#276 2016-10-09: Issue #267: in step mode we should move the focus to the current element
-		//if (delay != 0 || step)
-		//{
-		//	diagram.redraw();
-		//}
-		if (step) {
-			diagram.redraw(element);	// Doesn't work properly...
-		}
-		else if (delay != 0) {
-			diagram.redraw();
-		}
+		// START KGU#276 2016-10-09: Issue #269: Now done in checkBreakpoint()
+//		if (delay != 0 || step)
+//		{
+//			diagram.redraw();
+//		}
+//		if (step) {
+//			diagram.redraw(element);	// Doesn't work properly...
+//		}
+//		else if (delay != 0) {
+//			diagram.redraw();
+//		}
 		// END KGU#276 2016-10-09
 		// START KGU#143 2016-01-21: Bugfix #114 - make sure no compromising editing is done
 		diagram.doButtons();
@@ -2137,7 +2140,7 @@ public class Executor implements Runnable
 					delay();
 				}
 				// END KGU 2015-10-12
-				
+
 				// assignment
 				if (cmd.indexOf("<-") >= 0)
 				{
@@ -2693,7 +2696,7 @@ public class Executor implements Runnable
 					// START KGU#160 2016-04-26: Issue #137 - also log the result to the console
 					this.console.writeln("*** " + header + ": " + this.prepareValueForDisplay(resObj), Color.CYAN);
 					// END KGU#160 2016-04-26
-					// START KGU#147 2016-01-29: This "uncoverting" copied from tryOutput() didn't make sense...
+					// START KGU#147 2016-01-29: This "unconverting" copied from tryOutput() didn't make sense...
 					//String s = unconvert(resObj.toString());
 					//JOptionPane.showMessageDialog(diagram, s,
 					//		"Returned result", JOptionPane.INFORMATION_MESSAGE);

--- a/src/lu/fisch/structorizer/gui/AnalyserPreferences.java
+++ b/src/lu/fisch/structorizer/gui/AnalyserPreferences.java
@@ -44,6 +44,7 @@ package lu.fisch.structorizer.gui;
  *                                      checkboxOrder, order of checkboxes modified
  *      Kay Gürtzig     2016.11.10      Enh. #286: Tabs introduced, configuration array checkboxOrder replaced
  *                                      by map checkboxTabs.
+ *      Kay Gürtzig     2016.11.11      Issue #81: DPI-awareness workaround
  *
  ******************************************************************************************************
  *
@@ -154,39 +155,12 @@ public class AnalyserPreferences extends LangDialog {
 	}*/
 
 	private void initComponents() {
-		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
-		// Generated using JFormDesigner Evaluation license - Bob Fisch
+		// START KGU#287 2016-11-11: Issue #81
+		ImageIcon unselectedIcon = null;
+		ImageIcon selectedIcon = null;
+		// END KGU#287 2016-11-11
 		dialogPane = new JPanel();
 		contentPanel = new JTabbedPane();
-//		check1 = new JCheckBox();
-//		check2 = new JCheckBox();
-//		check3 = new JCheckBox();
-//		check4 = new JCheckBox();
-//		check5 = new JCheckBox();
-//		check6 = new JCheckBox();
-//		check7 = new JCheckBox();
-//		check8 = new JCheckBox();
-//		check9 = new JCheckBox();
-//		check10 = new JCheckBox();
-//		check11 = new JCheckBox();
-//		check12 = new JCheckBox();
-//		check13 = new JCheckBox();
-//		// START KGU#3 2015-11-03: Additional For loop checks
-//		check14 = new JCheckBox();
-//		// END KGU#3 2015-11-03
-//		// START KGU#2 2015-11-25: Additional CALL syntax check
-//		check15 = new JCheckBox();;
-//		// END KGU#2 2015-11-25
-//		// START KGU#78 2015-11-25: Additional JUMP syntax check
-//		check16 = new JCheckBox();;
-//		// END KGU#78 2015-11-25
-//		// START KGU#47 2015-11-28: Additional PARALLEL consistency check
-//		check17 = new JCheckBox();
-//		// END KGU#47 2015-11-28
-//		// START KGU#239 2016-08-12: New identifier collision checks
-//		check18 = new JCheckBox();
-//		check19 = new JCheckBox();
-//		// END KGU#239 2016-08-12
 		// START KGU 2016-09-22: New dummy entry at index position 0
 		//for (int i = 0; i < checkboxes.length; i++)
 		checkboxes[0] = null;
@@ -198,6 +172,16 @@ public class AnalyserPreferences extends LangDialog {
 			//checkboxes[i].setText(checkCaptions[i]);
 			checkboxes[i].setText(checkCaptions[i-1]);
 			// END KGU 2016-09-22
+			// START KGU#287 2016-11-11: Issue #81
+			if (unselectedIcon == null) {
+				unselectedIcon = scaleToggleIcon(checkboxes[i], false);
+			}
+			if (selectedIcon == null) {
+				selectedIcon = scaleToggleIcon(checkboxes[i], true);
+			}
+			checkboxes[i].setIcon(unselectedIcon);
+			checkboxes[i].setSelectedIcon(selectedIcon);
+			// END KGU#287 2016-11-11
 		}
 		buttonBar = new JPanel();
 		okButton = new JButton();
@@ -307,5 +291,5 @@ public class AnalyserPreferences extends LangDialog {
 		};
 		okButton.addActionListener(actionListener);
 	}
-
+	
 }

--- a/src/lu/fisch/structorizer/gui/AnalyserPreferences.java
+++ b/src/lu/fisch/structorizer/gui/AnalyserPreferences.java
@@ -42,6 +42,8 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.09.21      Enh. #249: check20 added (subroutine syntax)
  *      Kay Gürtzig     2016.09.22      checkboxes index mapping modified, duplicate entries removed from
  *                                      checkboxOrder, order of checkboxes modified
+ *      Kay Gürtzig     2016.11.10      Enh. #286: Tabs introduced, configuration array checkboxOrder replaced
+ *                                      by map checkboxTabs.
  *
  ******************************************************************************************************
  *
@@ -54,6 +56,8 @@ import lu.fisch.structorizer.locales.LangDialog;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
 
 import javax.swing.*;
 import javax.swing.border.*;
@@ -91,53 +95,38 @@ public class AnalyserPreferences extends LangDialog {
 		// DON'T FORGET to add a new entry to Root.analyserChecks for every
 		// text added here (and of course the checking code itself)!
 	};
-	// The order in which the checks (numbering starts with 1) are to be presented
-	private static final int[] checkboxOrder = {
-		// instructions, alternatives
-		3, 10, 11, 8, 4,
-		// loops
-		1, 14, 2,
-		// functions and calls
-		20, 13,	15,
-		// jumps and parallel sections
-		16, 17,
-		// identifiers and naming conventions
-		7, 9, 18, 19, /*LUX/MEN*/ 5, 6, 12
-	};
+	// START KGU#290 2016-11-10: Enh. #286 (grouping and distribution over several tabs)
+	// The order in which the checks (numbering starts with 1, index 0 induces an
+	// empty line) are to be presented and distributed over several tabs
+	private static final LinkedHashMap<String, int[]> checkboxTabs = new LinkedHashMap<String, int[]>();
+	static {
+		checkboxTabs.put("Algorithmic", new int[]{
+				// instructions
+				3, 11,
+				0,// alternatives
+				8, 4,
+				0,// loops
+				1, 14, 2,
+				0,// functions and calls
+				20, 13,	15,
+				0,// jumps and parallel sections
+				16, 17
+		});
+		checkboxTabs.put("Naming / Conventions", new int[]{
+				// identifiers and naming conventions
+				7, 9, 18, 19,
+				0/*LUX/MEN*/,
+				5, 6, 12,
+				0,// multiple command types
+				10
+		});
+	}
+	// END KGU#290 2016-11-10
 			
 	// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
 	// Generated using JFormDesigner Evaluation license - Bob Fisch
 	private JPanel dialogPane;
-	private JPanel contentPanel;
-//	public JCheckBox check1;
-//	public JCheckBox check2;
-//	public JCheckBox check3;
-//	public JCheckBox check4;
-//	public JCheckBox check5;
-//	public JCheckBox check6;
-//	public JCheckBox check7;
-//	public JCheckBox check8;
-//	public JCheckBox check9;
-//	public JCheckBox check10;
-//	public JCheckBox check11;
-//	public JCheckBox check12;
-//	public JCheckBox check13;
-//	// START KGU#3 2015-11-03: Additional FOR loop checks
-//	public JCheckBox check14;
-//	// END KGU#3 2015-11-03
-//	// START KGU#2 2015-11-25: Additional CALL syntax check
-//	public JCheckBox check15;
-//	// END KGU#2 2015-11-25
-//	// START KGU#78 2015-11-25: Additional JUMP syntax check
-//	public JCheckBox check16;
-//	// END KGU#78 2015-11-25
-//	// START KGU#47 2015-11-28: Additional PARALLEL consistency check
-//	public JCheckBox check17;
-//	// END KGU#47 2015-11-28
-//	// START KGU#239 2016-08-12: New identifier collision checks
-//	public JCheckBox check18;
-//	public JCheckBox check19;
-//	// END KGU#239 2016-08-12
+	private JTabbedPane contentPanel;
 	// START KGU 2016-09-22: Dummy entry at index 0 for more consistent error numbering
 	//public JCheckBox[] checkboxes = new JCheckBox[checkCaptions.length];
 	public JCheckBox[] checkboxes = new JCheckBox[checkCaptions.length+1];
@@ -168,7 +157,7 @@ public class AnalyserPreferences extends LangDialog {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
 		// Generated using JFormDesigner Evaluation license - Bob Fisch
 		dialogPane = new JPanel();
-		contentPanel = new JPanel();
+		contentPanel = new JTabbedPane();
 //		check1 = new JCheckBox();
 //		check2 = new JCheckBox();
 //		check3 = new JCheckBox();
@@ -234,19 +223,34 @@ public class AnalyserPreferences extends LangDialog {
 			
 			//======== contentPanel ========
 			{
-				// START KGU 2016-09-22: New dummy entry at index position 0
-				//contentPanel.setLayout(new GridLayout(checkboxes.length, 1));
-				contentPanel.setLayout(new GridLayout(checkboxes.length-1, 1));
-				// END KGU 2016-09-22
-
-				for (int i = 0; i < checkboxOrder.length; i++)
+				// START KGU#290 2016-11-10: Enh. #286 (tabs and gaps)
+				//contentPanel.setLayout(new GridLayout(checkboxes.length-1, 1));
+				//for (int i = 0; i < checkboxOrder.length; i++)
+				//{
+				//	contentPanel.add(checkboxes[checkboxOrder[i]]);
+				//}
+				for (Entry<String, int[]> entry: checkboxTabs.entrySet())
 				{
-					// START KGU 2016-09-22: New dummy entry at index position 0
-					//contentPanel.add(checkboxes[checkboxOrder[i]-1]);
-					contentPanel.add(checkboxes[checkboxOrder[i]]);
-					// END KGU 2016-09-22
+					JPanel panel = new JPanel();
+					JPanel wrapper = new JPanel();
+					int[] checklist = entry.getValue();
+					panel.setLayout(new GridLayout(checklist.length, 1));
+
+					for (int i = 0; i < checklist.length; i++)
+					{
+						int checkIndex = checklist[i];
+						if (checkIndex == 0) {
+							panel.add(new JLabel(""));
+						}
+						else {
+							panel.add(checkboxes[checkIndex]);
+						}
+					}
+					wrapper.setLayout(new BorderLayout());
+					wrapper.add(panel, BorderLayout.NORTH);	// Avoids the checkboxes being spread
+					contentPanel.addTab(entry.getKey(), wrapper);
 				}
-				
+				// END KGU#290 2016-11-10
 			}
 			dialogPane.add(contentPanel, BorderLayout.CENTER);
 

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -101,6 +101,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.11.09      Issue #81: Scale factor no longer rounded, Update font only scaled if factor > 1
  *      Kay Gürtzig     2016.11.15      Enh. #290: Opportunities to load arrangements via openNSD() and FilesDrop
  *      Kay Gürtzig     2016.11.16      Bugfix #291: upward cursor traversal ended in REPEAT loops
+ *      Kay Gürtzig     2016.11.17      Bugfix #114: Prerequisites for editing and transmutation during execution revised
  *
  ******************************************************************************************************
  *
@@ -772,7 +773,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 
     public void mouseClicked(MouseEvent e)
 	{
-                // select the element
+    	// select the element
 		if (e.getClickCount() == 1)
 		{
 			if (e.getSource()==this)
@@ -851,7 +852,10 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 //					redraw();
 //					//System.out.println("Re-selected on double-click: " + selected + ((selected instanceof Subqueue) ? ((Subqueue)selected).getSize() : ""));
 //				}
-				if (selected != null && !((selected instanceof Subqueue) && ((Subqueue)selected).getSize() > 0))
+				// START KGU#143 2016-11-17: Issue #114 - don't edit elements under execution
+				//if (selected != null && !((selected instanceof Subqueue) && ((Subqueue)selected).getSize() > 0))
+				if (canEdit())
+				// END KGU#143 2016-11-17
 				// END KGU#87 2015-11-22
 				{
 					// edit it
@@ -1602,7 +1606,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		//return canCopy() && !selected.executed && !selected.waited;
 		// START KGU#177 2016-07-06: Enh #158: mere re-formulation (equivalent)
 		//return canCopy() && !(selected instanceof Root) && !selected.executed && !selected.waited;
-		return canCopyNoRoot() && !selected.executed && !selected.waited;
+		return canCopyNoRoot() && !selected.isExecuted();
 		// END KGU#177 2016-07-06
 		// END KGU#177 2016-04-14
 	}
@@ -1632,12 +1636,20 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		return canCopy() && !(selected instanceof Root);
 	}
 	// END KGU#177 2016-07-06
+	
+	// START KGU#143 2016-11-17: Issue #114: Complex condition for editability
+	public boolean canEdit()
+	{
+		return selected != null && !this.selectedIsMultiple() &&
+				(!selected.isExecuted(false) || selected instanceof Instruction && !selected.executed);
+	}
+	// END KGU#143 2016-11-17
 
 	// START KGU#199 2016-07-06: Enh. #188: Element conversions
 	public boolean canTransmute()
 	{
 		boolean isConvertible = false;
-		if (selected != null && !selected.executed && !selected.waited)
+		if (selected != null && !selected.isExecuted())
 		{
 			if (selected instanceof Instruction)
 			{

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -102,6 +102,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.11.15      Enh. #290: Opportunities to load arrangements via openNSD() and FilesDrop
  *      Kay Gürtzig     2016.11.16      Bugfix #291: upward cursor traversal ended in REPEAT loops
  *      Kay Gürtzig     2016.11.17      Bugfix #114: Prerequisites for editing and transmutation during execution revised
+ *      Kay Gürtzig     2016.11.18/19   Issue #269: Scroll to the element associated to a selected Analyser error
  *
  ******************************************************************************************************
  *
@@ -823,8 +824,13 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 						// select the new one
 						selected = ele;
 						ele.setSelected(true);
+						
 						// redraw the diagram
-						redraw();
+						// START KGU#276 2016-11-18: Issue #269 - ensure the associated element be visible
+						//redraw();
+						redraw(ele);
+						// END KGU#276 2016-11-18
+						
 						// do the button thing
 						if(NSDControl!=null) NSDControl.doButtons();
 					}
@@ -892,17 +898,26 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
     }
     // END KGU#143 2016-01-21
 
-    // START KGU#276 2016-10-09: Issue #269 attempt - but doesn't work
+    // START KGU#276 2016-10-09: Issue #269
     /**
-     * Redraw the current diagram and scroll to the given element
+     * Scroll to the given element and redraw the current diagram
      * @param element - the element to gain the focus
      */
     public void redraw(Element element)
     {
+    	Rectangle rect = element.getRectOffDrawPoint().getRectangle();
+    	// START KGU#276 2016-11-19: Issue #269 Ensure the element is shown left-bound
+    	if (!(element instanceof Alternative || element instanceof Case))
+    	{
+    		Rectangle visibleRect = new Rectangle();
+    		this.computeVisibleRect(visibleRect);
+    		if (rect.width > visibleRect.width) {
+    			rect.width = visibleRect.width;
+    		}
+    	}
+    	// END KGU#276 2016-11-19
+    	scrollRectToVisible(rect);
     	redraw();	// This is to make sure the drawing rectangles are correct
-    	// FIXME Doesn't work as intended
-//		scrollRectToVisible(element.getRectOffDrawPoint().getRectangle());
-//    	redraw();	// And this is to avoid partially redrawn environment
     }
     // END KGU#276 2016-10-09
     
@@ -5137,10 +5152,10 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
     		selected.setSelected(true);
 			
     		// START KGU#177 2016-04-14: Enh. #158 - scroll to the selected element
-			this.scrollRectToVisible(selected.getRectOffDrawPoint().getRectangle());
+			//redraw();
+			redraw(selected);
 			// END KGU#177 2016-04-14
 			
-			redraw();
 			// START KGU#177 2016-04-24: Bugfix - buttons haven't been updated 
 			this.doButtons();
 			// END KGU#177 2016-04-24
@@ -5185,8 +5200,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
     		if (newSelection)
     		{
         		selected.setSelected(true);
-    			this.scrollRectToVisible(selected.getRectOffDrawPoint().getRectangle());
-    			redraw();
+    			redraw(selected);
     			this.doButtons();
     		}
     	}

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -100,6 +100,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.11.06      Issue #279: All references to method HashMap.getOrDefault() replaced
  *      Kay Gürtzig     2016.11.09      Issue #81: Scale factor no longer rounded, Update font only scaled if factor > 1
  *      Kay Gürtzig     2016.11.15      Enh. #290: Opportunities to load arrangements via openNSD() and FilesDrop
+ *      Kay Gürtzig     2016.11.16      Bugfix #291: upward cursor traversal ended in REPEAT loops
  *
  ******************************************************************************************************
  *
@@ -4997,7 +4998,10 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
     		case CMD_UP:
     			if (selected instanceof Repeat)
     			{
-    				y = ((Repeat)selected).getRectOffDrawPoint().bottom - 2;
+    				// START KGU#292 2016-11-16: Bugfix #291
+    				//y = ((Repeat)selected).getRectOffDrawPoint().bottom - 2;
+    				y = ((Repeat)selected).getBody().getRectOffDrawPoint().bottom - 2;
+    				// END KGU#292 2016-11-16
     			}
     			else if (selected instanceof Root)
     			{

--- a/src/lu/fisch/structorizer/gui/Editor.java
+++ b/src/lu/fisch/structorizer/gui/Editor.java
@@ -20,7 +20,8 @@
 
 package lu.fisch.structorizer.gui;
 
-/******************************************************************************************************
+/*
+ ******************************************************************************************************
  *
  *      Author:         Bob Fisch
  *
@@ -45,12 +46,14 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.07.21      Enh. #197: Selection may be expanded by Shift-Up and Shift-Down (KGU#206)
  *      Kay Gürtzig     2016.08.02      Enh. #215: popupBreakTrigger added
  *      Kay Gürtzig     2016.10.13      Enh. #277: New toolbar button (+ context menu item) for disabling elements
+ *      Kay Gürtzig     2016.11.17      Bugfix #114: Prerequisites for editing and transmutation during execution revised
  *
  ******************************************************************************************************
  *
  *      Comment:		/
  *
- ******************************************************************************************************///
+ ******************************************************************************************************
+ */
 
 
 import com.kobrix.notebook.gui.AKDockLayout;
@@ -884,7 +887,10 @@ public class Editor extends LangPanel implements NSDController, ComponentListene
 		// editing
 		// START KGU#87 2015-11-22: Don't allow editing if multiple elements are selected
 		//btnEdit.setEnabled(conditionAny);
-		btnEdit.setEnabled(conditionAny && !diagram.selectedIsMultiple());
+		// START KGU#143 2016-11-17: Bugfix #114 - unstructured elements may be edited if parent is waiting
+		//btnEdit.setEnabled(conditionAny && !diagram.selectedIsMultiple());
+		btnEdit.setEnabled(diagram.canEdit());
+		// END KGU#143 2016-11-17
 		// END KGU#87 2015-11-22
 		// START KGU#143 2016-01-21: Bugfix #114 - we must differentiate among cut and copy
 		//btnDelete.setEnabled(diagram.canCutCopy());
@@ -896,8 +902,11 @@ public class Editor extends LangPanel implements NSDController, ComponentListene
 		btnTransmute.setEnabled(diagram.canTransmute());
 		// END KGU#199 2016-07-06
 		// START KGU#87 2015-11-22: Don't allow editing if multiple elements are selected
-		//popuEdit.setEnabled(conditionAny);
-		popupEdit.setEnabled(conditionAny && !diagram.selectedIsMultiple());
+		//popupEdit.setEnabled(conditionAny);
+		// START KGU#143 2016-11-17: Bugfix #114 - unstructured elements may be edited if parent is waiting
+		//popupEdit.setEnabled(conditionAny && !diagram.selectedIsMultiple());
+		popupEdit.setEnabled(diagram.canEdit());
+		// END KGU#143 2016-11-17
 		// END KGU#87 2015-11-22
 		// START KGU#143 2016-01-21: Bugfix #114 - we must differentiate among cut and copy
 		//popupDelete.setEnabled(condition);

--- a/src/lu/fisch/structorizer/gui/ExportOptionDialoge.java
+++ b/src/lu/fisch/structorizer/gui/ExportOptionDialoge.java
@@ -20,7 +20,8 @@
 
 package lu.fisch.structorizer.gui;
 
-/******************************************************************************************************
+/*
+ ******************************************************************************************************
  *
  *      Author:         Bob Fisch
  *
@@ -30,22 +31,25 @@ package lu.fisch.structorizer.gui;
  *
  *      Revision List
  *
- *      Author           Date         Description
- *      ------           ----         -----------
- *      Bob Fisch        2012.07.02   First Issue
- *      Kay Gürtzig      2016.04.01   Enh. #144: noConversionCheckBox and cbPrefGenerator added
- *      Kay Gürtzig      2016.04.04   Enh. #149: cbCharset added
- *      Kay Gürtzig      2016.07.20   Enh. #160: new option to involve called subroutines (= KGU#178)
- *      Kay Gürtzig      2016.07.25   Size setting dropped. With the current layout, pack() is fine (KGU#212).
- *      Kay Gürtzig      2016.07.26   Bug #204: Constructor API modified to ensure language translation before pack()
+ *      Author          Date         Description
+ *      ------          ----         -----------
+ *      Bob Fisch       2012.07.02   First Issue
+ *      Kay Gürtzig     2016.04.01   Enh. #144: noConversionCheckBox and cbPrefGenerator added
+ *      Kay Gürtzig     2016.04.04   Enh. #149: cbCharset added
+ *      Kay Gürtzig     2016.07.20   Enh. #160: new option to involve called subroutines (= KGU#178)
+ *      Kay Gürtzig     2016.07.25   Size setting dropped. With the current layout, pack() is fine (KGU#212).
+ *      Kay Gürtzig     2016.07.26   Bug #204: Constructor API modified to ensure language translation before pack()
+ *      Kay Gürtzig     2016.11.11   Issue #81: DPI-awareness workaround for checkboxes
  *
  ******************************************************************************************************
  *
  *      Comment:		I used JFormDesigner to design this window graphically.
  *
- ******************************************************************************************************///
+ ******************************************************************************************************
+ */
 
 import lu.fisch.structorizer.locales.LangDialog;
+
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
@@ -56,6 +60,8 @@ import java.io.BufferedInputStream;
 import java.nio.charset.Charset;
 import java.util.Set;
 import java.util.Vector;
+
+import javax.swing.ImageIcon;
 
 import lu.fisch.structorizer.helpers.GENPlugin;
 import lu.fisch.structorizer.parsers.GENParser;
@@ -116,6 +122,11 @@ public class ExportOptionDialoge extends LangDialog
         // START KGU#178 2016-07-20: Enh. #160
         chkExportSubroutines = new javax.swing.JCheckBox();
         // END KGU#178 2016-07-20
+        
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaroundfor checkboxes)
+        ImageIcon unselectedBox = scaleToggleIcon(noConversionCheckBox, false);
+        ImageIcon selectedBox = scaleToggleIcon(noConversionCheckBox, true);
+        // END KGU#287 2016-11-11
 
         setTitle("Export options ...");
 
@@ -147,6 +158,10 @@ public class ExportOptionDialoge extends LangDialog
         	}
         });
         // END KGU#168 2016-04-04
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+        chkCharsetAll.setIcon(unselectedBox);
+        chkCharsetAll.setSelectedIcon(selectedBox);
+        // END KGU#287 2016-11-11
 
         // START KGU#171 2016-04-01: Enh. #144 - new: preferred code export language
         lbVoid.setText(" ");	// FIXME: Can we replace this by insets?
@@ -169,6 +184,10 @@ public class ExportOptionDialoge extends LangDialog
         noConversionCheckBox.setText("No conversion of the expression/instruction contents.");
         noConversionCheckBox.setToolTipText("Select this option if the text content of your elements already represents target language syntax.");
         // END KGU#162 2016-03-31
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+        noConversionCheckBox.setIcon(unselectedBox);
+        noConversionCheckBox.setSelectedIcon(selectedBox);
+        // END KGU#287 2016-11-11
 
         commentsCheckBox.setText("Export instructions as comments.");
 //        commentsCheckBox.addActionListener(new ActionListener() {
@@ -176,6 +195,10 @@ public class ExportOptionDialoge extends LangDialog
 //                commentsCheckBoxActionPerformed(evt);
 //            }
 //        });
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+        commentsCheckBox.setIcon(unselectedBox);
+        commentsCheckBox.setSelectedIcon(selectedBox);
+        // END KGU#287 2016-11-11
 
         jLabel1.setText("Please select the options you want to activate ...");
 
@@ -186,6 +209,10 @@ public class ExportOptionDialoge extends LangDialog
                 bracesCheckBoxActionPerformed(evt);
             }
         });
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+        bracesCheckBox.setIcon(unselectedBox);
+        bracesCheckBox.setSelectedIcon(selectedBox);
+        // END KGU#287 2016-11-11
 
         lineNumbersCheckBox.setText("Generate line numbers on export to BASIC.");
         lineNumbersCheckBox.addActionListener(new ActionListener() {
@@ -193,6 +220,10 @@ public class ExportOptionDialoge extends LangDialog
                 lineNumbersCheckBoxActionPerformed(evt);
             }
         });
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+        lineNumbersCheckBox.setIcon(unselectedBox);
+        lineNumbersCheckBox.setSelectedIcon(selectedBox);
+        // END KGU#287 2016-11-11
 
         chkExportSubroutines.setText("Involve called subroutines");
         chkExportSubroutines.addActionListener(new ActionListener() {
@@ -200,6 +231,10 @@ public class ExportOptionDialoge extends LangDialog
         		subroutinesCheckBoxActionPerformed(evt);
         	}
         });
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+        chkExportSubroutines.setIcon(unselectedBox);
+        chkExportSubroutines.setSelectedIcon(selectedBox);
+        // END KGU#287 2016-11-11
         
         jButton1.setText("OK");
         jButton1.addActionListener(new ActionListener() {

--- a/src/lu/fisch/structorizer/gui/ImportOptionDialog.java
+++ b/src/lu/fisch/structorizer/gui/ImportOptionDialog.java
@@ -29,6 +29,7 @@ import java.awt.event.ActionListener;
 import java.nio.charset.Charset;
 import java.util.Set;
 
+import javax.swing.ImageIcon;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.TitledBorder;
 
@@ -48,6 +49,7 @@ import lu.fisch.structorizer.locales.LangDialog;
  *      Author          Date            Description
  *      ------          ----            -----------
  *      kay             2016.09.25      First Issue
+ *      Kay Gürtzig     2016.11.11      Issue #81: DPI-awareness workaround for checkboxes
  *
  ******************************************************************************************************
  *
@@ -105,6 +107,11 @@ public class ImportOptionDialog extends LangDialog {
 
         setTitle("Import options ...");
 
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaroundfor checkboxes)
+        ImageIcon unselectedBox = scaleToggleIcon(chkRefactorOnLoading, false);
+        ImageIcon selectedBox = scaleToggleIcon(chkRefactorOnLoading, true);
+        // END KGU#287 2016-11-11
+
         org.jdesktop.layout.GroupLayout jPanel1Layout = new org.jdesktop.layout.GroupLayout(pnlTop);
         pnlTop.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
@@ -131,10 +138,18 @@ public class ImportOptionDialog extends LangDialog {
         		charsetListChanged((String)cbCharset.getSelectedItem());
         	}
         });
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+        chkCharsetAll.setIcon(unselectedBox);
+        chkCharsetAll.setSelectedIcon(selectedBox);
+        // END KGU#287 2016-11-11
 
         chkRefactorOnLoading.setText("Replace keywords on loading a diagram (refactoring).");
         chkRefactorOnLoading.setToolTipText("Select this option if all configurable keywords in the daiagram are to be adapted to the current parser preferences.");
         chkRefactorOnLoading.setAlignmentX(LEFT_ALIGNMENT);
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+        chkRefactorOnLoading.setIcon(unselectedBox);
+        chkRefactorOnLoading.setSelectedIcon(selectedBox);
+        // END KGU#287 2016-11-11
 
         //chkOfferRefactoringIni.setText("Offer refactoring on loading preferences from file.");
         //chkOfferRefactoringIni.setToolTipText("Select this option if you want to be asked whether to refactor diagrams whenever you load preferences from file.");

--- a/src/lu/fisch/structorizer/gui/InputBox.java
+++ b/src/lu/fisch/structorizer/gui/InputBox.java
@@ -30,19 +30,21 @@ package lu.fisch.structorizer.gui;
  *
  *     Revision List
  *
- *     Author       Date        Description
- *     ------       ----        -----------
- *     Bob Fisch    2007.12.23  First Issue
- *     Kay Gürtzig  2015.10.12  A checkbox added for breakpoint control (KGU#43)
- *     Kay Gürtzig  2015.10.14  Element-class-specific language support (KGU#42)
- *     Kay Gürtzig  2015.10.25  Hook for subclassing added to method create() (KGU#3)
- *     Kay Gürtzig  2016.04.26  Issue #165: Focus transfer reset to Tab and Shift-Tab
- *     Kay Gürtzig  2016.07.14  Enh. #180: Initial focus dependent on switchTextComment mode (KGU#169)
- *     Kay Gürtzig  2016.08.02  Enh. #215: Breakpoint trigger counts partially implemented
- *     Kay Gürtzig  2016.09.13  Bugfix #241: Obsolete mechanisms removed (remnants of KGU#42)
- *     Kay Gürtzig  2016.09.22  Bugfix #241 revised by help of a LangDialog API modification
- *     Kay Gürtzig  2016.10.13  Enh. #270: New checkbox chkDisabled
- *     Kay Gürtzig  2016.11.02  Issue #81: Workaround for lacking DPI awareness
+ *      Author          Date        Description
+ *      ------          ----        -----------
+ *      Bob Fisch       2007.12.23  First Issue
+ *      Kay Gürtzig     2015.10.12  A checkbox added for breakpoint control (KGU#43)
+ *      Kay Gürtzig     2015.10.14  Element-class-specific language support (KGU#42)
+ *      Kay Gürtzig     2015.10.25  Hook for subclassing added to method create() (KGU#3)
+ *      Kay Gürtzig     2016.04.26  Issue #165: Focus transfer reset to Tab and Shift-Tab
+ *      Kay Gürtzig     2016.07.14  Enh. #180: Initial focus dependent on switchTextComment mode (KGU#169)
+ *      Kay Gürtzig     2016.08.02  Enh. #215: Breakpoint trigger counts partially implemented
+ *      Kay Gürtzig     2016.09.13  Bugfix #241: Obsolete mechanisms removed (remnants of KGU#42)
+ *      Kay Gürtzig     2016.09.22  Bugfix #241 revised by help of a LangDialog API modification
+ *      Kay Gürtzig     2016.10.13  Enh. #270: New checkbox chkDisabled
+ *      Kay Gürtzig     2016.11.02  Issue #81: Workaround for lacking DPI awareness
+ *      Kay Gürtzig     2016.11.09  Issue #81: Scale factor no longer rounded but ensured to be >= 1
+ *      Kay Gürtzig     2016.11.11  Issue #81: DPI-awareness workaround for checkboxes
  *
  ******************************************************************************************************
  *
@@ -103,13 +105,7 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
     public boolean forInsertion = false;		// If this dialog is used to setup a new element (in contrast to updating an existing element)
     // END KGU 2015-10-14
 
-    // START KGU#169 2016-07-14: Enh. #180: helps to enable focus control
-    @Deprecated
-    protected void setPreferredSize() {
-        setSize(500, 400);        
-    }
-    // END KGU#169 2016-07-14
-    // START KGU#287 2016-11-02: Issue #81 (DPI awaeness workaround)
+    // START KGU#287 2016-11-02: Enh. #180, Issue #81 (DPI awareness workaround)
     protected void setPreferredSize(double scaleFactor) {
         setSize((int)(500 * scaleFactor), (int)(400 * scaleFactor));        
     }
@@ -125,11 +121,22 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
         //setSize(500, 400);
         // END KGU#169 2016-07-14
         
-        // START KGU#287 2016-11-02: Issue #81 (DPI awaeness workaround)
-		double scaleFactor = Double.valueOf(Ini.getInstance().getProperty("scaleFactor","1")).intValue();        
+        // START KGU#287 2016-11-02: Issue #81 (DPI awareness workaround)
+		double scaleFactor = Double.valueOf(Ini.getInstance().getProperty("scaleFactor","1"));
+		if (scaleFactor < 1) scaleFactor = 1.0;
         // END KGU#287 2016-11-02
-        
-        // show form
+        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+		if (scaleFactor > 1) {
+			ImageIcon unselectedBox = scaleToggleIcon(chkDisabled, false);
+			ImageIcon selectedBox = scaleToggleIcon(chkDisabled, true);
+			chkDisabled.setIcon(unselectedBox);
+			chkDisabled.setSelectedIcon(selectedBox);
+			chkBreakpoint.setIcon(unselectedBox);
+			chkBreakpoint.setSelectedIcon(selectedBox);
+		}
+		// END KGU#287 2016-11-11
+
+		// show form
         setVisible(false);
         // set action to perform if closed
         setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
@@ -308,7 +315,6 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
 
         // START KGU#91+KGU#169 2016-07-14: Enh. #180 (also see #39 and #142)
         this.pack();	// This makes focus control possible but must precede the size setting
-        setPreferredSize();
         setPreferredSize(scaleFactor);
         if (Element.E_TOGGLETC) {
             txtComment.requestFocusInWindow();

--- a/src/lu/fisch/structorizer/gui/Menu.java
+++ b/src/lu/fisch/structorizer/gui/Menu.java
@@ -66,6 +66,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.10.11      Enh. #267: error15 renamed to error15_1, new error15_2
  *      Kay Gürtzig     2016.10.13      Enh. #270: Menu items for the disabling of elements
  *      Kay Gürtzig     2016.10.16      Enh. #272: Menu items for the replacement of Turtleizer command sets
+ *      Kay Gürtzig     2016.11.17      Bugfix #114: Prerequisites for editing during execution revised
  *
  ******************************************************************************************************
  *
@@ -1073,7 +1074,10 @@ public class Menu extends LangMenuBar implements NSDController
 			// editing
 			// START KGU#87 2015-11-22: Don't allow editing if multiple elements are selected
 			//menuDiagramEdit.setEnabled(conditionAny);
-			menuDiagramEdit.setEnabled(conditionAny && !diagram.selectedIsMultiple());
+			// START KGU#143 2016-11-17: Bugfix #114 - unstructured elements may be edited if parent is waiting
+			//menuDiagramEdit.setEnabled(conditionAny && !diagram.selectedIsMultiple());
+			menuDiagramEdit.setEnabled(diagram.canEdit());
+			// END KGU#143 2016-11-7
 			// END KGU#87 2015-11-22
 			// START KGU#143 2016-01-21: Bugfix #114 - we must differentiate among cut and copy
 			//menuDiagramDelete.setEnabled(diagram.canCutCopy());

--- a/src/lu/fisch/structorizer/gui/ParserPreferences.java
+++ b/src/lu/fisch/structorizer/gui/ParserPreferences.java
@@ -37,6 +37,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2015.11.08      Enh. #10: step keyword setting manually added (FOR loop)
  *      Kay Gürtzig     2016.03.21      Enh. #84: FOR-IN loop settings manually added
  *      Kay Gürtzig     2016.03.23      Enh. #23: Settings for JUMP statements prepared (but not enabled)
+ *      Kay Gürtzig     2016.11.11      Issue #81: DPI-awareness workaround for checkboxes
  *
  ******************************************************************************************************
  *
@@ -338,6 +339,12 @@ public class ParserPreferences extends LangDialog {
 
 				//---- chkIgnoreCase ---
 				chkIgnoreCase.setText("Ignore case");
+		        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaroundfor checkboxes)
+		        ImageIcon unselectedBox = scaleToggleIcon(chkIgnoreCase, false);
+		        ImageIcon selectedBox = scaleToggleIcon(chkIgnoreCase, true);
+		        chkIgnoreCase.setIcon(unselectedBox);
+		        chkIgnoreCase.setSelectedIcon(selectedBox);
+		        // END KGU#287 2016-11-11				
 				buttonBar.add(chkIgnoreCase);
 				
 				//---- okButton ----

--- a/src/lu/fisch/structorizer/gui/Preferences.java
+++ b/src/lu/fisch/structorizer/gui/Preferences.java
@@ -35,6 +35,7 @@ package lu.fisch.structorizer.gui;
  *      ------			----			-----------
  *      Bob Fisch       2007.12.31      First Issue
  *      Kay Gürtzig     2016.11.01      Issue #81 (CPI awareness): Proper scaling of all explicit sizes
+ *      Kay Gürtzig     2016.11.11      Issue #81: DPI-awareness workaround for checkboxes/radio buttons
  *
  ******************************************************************************************************
  *
@@ -243,6 +244,12 @@ public class Preferences extends LangDialog implements ActionListener, KeyListen
 							pnlContent.add(lblAltContent, BorderLayout.NORTH);
 							pnlContent.add(edtAlt, BorderLayout.CENTER);
 							altPadRight.setText("Enlarge FALSE");
+					        // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaroundfor checkboxes)
+					        ImageIcon unselectedBox = scaleToggleIcon(altPadRight, false);
+					        ImageIcon selectedBox = scaleToggleIcon(altPadRight, true);
+					        altPadRight.setIcon(unselectedBox);
+					        altPadRight.setSelectedIcon(selectedBox);
+					        // END KGU#287 2016-11-11
 							pnlContent.add(altPadRight, BorderLayout.SOUTH);
 						}
 						pnlAlt.add(pnlContent, BorderLayout.CENTER);

--- a/src/lu/fisch/structorizer/gui/SelectedSequence.java
+++ b/src/lu/fisch/structorizer/gui/SelectedSequence.java
@@ -20,7 +20,8 @@
 
 package lu.fisch.structorizer.gui;
 
-/******************************************************************************************************
+/*
+ ******************************************************************************************************
  *
  *      Author:         Kay Guertzig
  *
@@ -41,12 +42,14 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.07.06      Bugfix in method removeElement() for enh. #188 (element conversion)
  *      Kay Gürtzig     2016.07.21      Bugfix #197 (selection moves by cursor keys); KGU#207 (getElementByCoord() revised)
  *      Kay Gürtzig     2016.10.13      Enh. #277: Method setDisabled(boolean) implemented
+ *      Kay Gürtzig     2016.11.17      Bugfix #114: isExecuted() revised (signatures too)
  *
  ******************************************************************************************************
  *
  *      Comment:		/
  *
- ******************************************************************************************************///
+ ******************************************************************************************************
+ */
 
 import java.awt.Color;
 import java.awt.FontMetrics;
@@ -396,8 +399,9 @@ public class SelectedSequence extends Element implements IElementSequence {
 	 * @see lu.fisch.structorizer.elements.Element#isExecuted()
 	 */
 	@Override
-	public boolean isExecuted()
+	public boolean isExecuted(boolean ignored)
 	{
+		// START KGU#143 2016-11-17: Bugfix #114 - We must assume involvement if parent is in waited element
 		boolean involved = false;
 		for (int index = this.firstIndex; !involved && index <= this.lastIndex; index++)
 		{

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -5,7 +5,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-07 (2016.11.16)
+Current development version: 3.25-07 (2016.11.18)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -59,6 +59,7 @@ Current development version: 3.25-07 (2016.11.16)
 - 07: Enh. #289: Arranger files (.arr, .arrz) may now be dragged into Arranger <2>
 - 07: Enh. #290: Arranger files (.arr, .arrz) loadable from Structorizer, too <2>
 - 07: Bugfix #291: REPEAT loops caught cursor up traversal <2> 
+- 07: Bugfix #114: Prerequisites for editing and transmutation during execution revised <2>
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -5,7 +5,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-07 (2016.11.18)
+Current development version: 3.25-07 (2016.11.19)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -60,6 +60,8 @@ Current development version: 3.25-07 (2016.11.18)
 - 07: Enh. #290: Arranger files (.arr, .arrz) loadable from Structorizer, too <2>
 - 07: Bugfix #291: REPEAT loops caught cursor up traversal <2> 
 - 07: Bugfix #114: Prerequisites for editing and transmutation during execution revised <2>
+- 07: Issue #269: Selecting an Analyser error now scrolls to the element <2>
+- 07: Issue #269: Automatic scrolling to the element currently executed <2>
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -1,11 +1,11 @@
-Legend:
+﻿Legend:
 -------
 [Foo]   -->     idea provided by Foo, coding done by Bob Fisch
 [Foo]2  -->     idea provided by Foo, coding done by Kay Gürtzig
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-07 (2016.11.15)
+Current development version: 3.25-07 (2016.11.16)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -58,6 +58,7 @@ Current development version: 3.25-07 (2016.11.15)
 - 07: Issue #288: Radio button fix in FOR loop editor <2>
 - 07: Enh. #289: Arranger files (.arr, .arrz) may now be dragged into Arranger <2>
 - 07: Enh. #290: Arranger files (.arr, .arrz) loadable from Structorizer, too <2>
+- 07: Bugfix #291: REPEAT loops caught cursor up traversal <2> 
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -4,7 +4,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-06 (2016.11.08)
+Current development version: 3.25-07 (2016.11.10)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -49,9 +49,10 @@ Current development version: 3.25-06 (2016.11.08)
 - 05: Bugfix #272: The Turtle instruction replacement produced void undo entries <2>
 - 05: Bugfix #268: Controlling the output console font sometimes changed colours <2>
 - 05: Issue #81: Ini-based scaling workaround for icons, fonts, and frames in high DPI <2>
-- 06: Bugfix #281/#282: Again, a Java 1.8 method was the show stopper for OpenJDK <2>
+- 06: Bugfix #281/#282: Again, a Java 1.8 method was a show-stopper for OpenJDK <2>
 - 06: Enh. #270: Translations for controls disabling elements in EN, DE, ES, IT <2>
 - 06: Issue #271: Correction of C++ code export for output instructions <2>
+- 07: Enh. #286: Analyser Preferences now organized into two tabs with groups <2>
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -4,7 +4,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-07 (2016.11.11)
+Current development version: 3.25-07 (2016.11.14)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -54,7 +54,8 @@ Current development version: 3.25-07 (2016.11.11)
 - 06: Issue #271: Correction of C++ code export for output instructions <2>
 - 07: Enh. #286: Analyser Preferences now organized into two tabs with groups <2>
 - 07: Issue #81: Checkbox and radio button scaling implemented <2>
-- 07: Issue #288: Radio button fix in FOR loop editor <2>  
+- 07: Issue #288: Radio button fix in FOR loop editor <2>
+- 07: Enh. #289: Arranger files (.arr, .arrz) may now be dragged into Arranger <2>
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -4,7 +4,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-07 (2016.11.14)
+Current development version: 3.25-07 (2016.11.15)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -56,6 +56,7 @@ Current development version: 3.25-07 (2016.11.14)
 - 07: Issue #81: Checkbox and radio button scaling implemented <2>
 - 07: Issue #288: Radio button fix in FOR loop editor <2>
 - 07: Enh. #289: Arranger files (.arr, .arrz) may now be dragged into Arranger <2>
+- 07: Enh. #290: Arranger files (.arr, .arrz) loadable from Structorizer, too <2>
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -4,7 +4,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-07 (2016.11.10)
+Current development version: 3.25-07 (2016.11.11)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -53,6 +53,8 @@ Current development version: 3.25-07 (2016.11.10)
 - 06: Enh. #270: Translations for controls disabling elements in EN, DE, ES, IT <2>
 - 06: Issue #271: Correction of C++ code export for output instructions <2>
 - 07: Enh. #286: Analyser Preferences now organized into two tabs with groups <2>
+- 07: Issue #81: Checkbox and radio button scaling implemented <2>
+- 07: Issue #288: Radio button fix in FOR loop editor <2>  
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/locales/LangDialog.java
+++ b/src/lu/fisch/structorizer/locales/LangDialog.java
@@ -34,7 +34,8 @@ package lu.fisch.structorizer.locales;
  *     ------       ----        -----------
  *     Bob Fisch    2008.01.14  First Issue
  *     Bob Fisch    2016.08.02  Fundamentally redesigned
- *     Kay Gürtzig  2016.09.21  API enhanced (initLang(), adjustLangDependentComponents()) to facilitate bugfix #241 
+ *     Kay Gürtzig  2016.09.21  API enhanced (initLang(), adjustLangDependentComponents()) to facilitate bugfix #241
+ *     Kay Gürtzig  2016.11.11  Issue #81: Method scaleCheckBoxIcon added (DPI awareness workaround) 
  *
  ******************************************************************************************************
  *
@@ -46,8 +47,10 @@ package lu.fisch.structorizer.locales;
 import java.awt.*;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
 
 import javax.swing.*;
+
 import lu.fisch.structorizer.gui.IconLoader;
 
 /**
@@ -120,4 +123,44 @@ public class LangDialog extends JDialog {
     	// MAY BE OVERRIDDEN BY SUBCLASSES
     }
     // END KGU#246 2016-09-21
+    
+    // START KGU#287 2016-11-11: Issue #81 (DPI-awareness workaround)
+    /**
+     * Returns a scaled checkbox icon for JCheckbox checkbox in mode selected
+     * @param checkbox - the checkbox the icon is recested for
+     * @param selected - the kind of icon (true = selected, false = unselected)
+     * @return an ImageIcon scaled to the font size of checkbox
+     */
+    protected static ImageIcon scaleToggleIcon(JToggleButton checkbox, boolean selected)
+    {
+        boolean prevState = checkbox.isSelected();
+        FontMetrics boxFontMetrics = checkbox.getFontMetrics(checkbox.getFont());
+        Icon boxIcon = selected ? checkbox.getSelectedIcon() : checkbox.getIcon();
+        if (boxIcon == null) {
+            checkbox.setSelected(selected);
+            String propertyName = "CheckBox.icon";
+            if (checkbox instanceof JRadioButton) {
+            	propertyName = "RadioButton.icon";
+            }
+            boxIcon = UIManager.getIcon(propertyName);
+        }
+        int type = BufferedImage.TYPE_INT_ARGB;
+        BufferedImage boxImage = new BufferedImage(
+                boxIcon.getIconWidth(), boxIcon.getIconHeight(), type);
+        Graphics2D g2 = boxImage.createGraphics();
+        try {
+            boxIcon.paintIcon(checkbox, g2, 0, 0);
+        }
+        finally {
+            g2.dispose();
+        }
+        ImageIcon newBoxIcon = new ImageIcon(boxImage);
+        Image finalBoxImage = newBoxIcon.getImage().getScaledInstance(
+                boxFontMetrics.getHeight(), boxFontMetrics.getHeight(), Image.SCALE_SMOOTH
+                );
+        checkbox.setSelected(prevState);
+        return new ImageIcon(finalBoxImage);
+    }
+    // END KGU#287 2016-11-11
+
 }

--- a/src/lu/fisch/structorizer/locales/de.txt
+++ b/src/lu/fisch/structorizer/locales/de.txt
@@ -720,6 +720,8 @@ Surface.msgUnsavedDiagrams.text=Folgende Diagramme konnten nicht gesichert werde
 Surface.msgUnsavedHint.text=Vielleicht möchten Sie die Diagramme erst per Doppelklick von einem Structorizer sichern lassen.
 Surface.msgUnsavedContinue.text=Trotzdem fortfahren?
 Surface.msgNoArrFile.text=Keine Arranger-Datei (arr) gefunden
+Surface.msgDefectiveArr.text=Defekte Anordnungsdatei.
+Surface.msgDefectiveArrz.text=Defektes portables Anordnungsarchiv.
 
 -----> Executor
 -----[ Control ]-----

--- a/src/lu/fisch/structorizer/locales/de.txt
+++ b/src/lu/fisch/structorizer/locales/de.txt
@@ -84,6 +84,7 @@
  *      Kay Gürtzig         2016.10.16  Enh. #272: Menu.menuEditUpgradeTurtle, Menu.menuDowngradeTurtle added
  *      Kay Gürtzig         2016.10.18  Enh. #267: Analyser check 15 reformulated.
  *      Kay Gürtzig         2016.11.08  Enh. #270: Editor.btnDisable.tooltip added
+ *      Kay Gürtzig         2016.11.10  Enh. #286: AnalyserPreferences tabs
  *
  ******************************************************************************************************
  *
@@ -316,6 +317,8 @@ Menu.error20.text=Ein Unterprogrammkopf muss mindestens die Klammern einer (evtl
 
 -----[ AnalyserPreferences ]-----
 AnalyserPreferences.title=Überprüfungs-Einstellungen
+AnalyserPreferences.contentPanel.tab.0=Algorithmisch
+AnalyserPreferences.contentPanel.tab.1=Bezeichner / Konventionen
 AnalyserPreferences.checkboxes.1.text=Manipulationen an Kontrollvariablen von FOR-Schleifen melden.
 AnalyserPreferences.checkboxes.2.text=Schleifen auf Endloszyklen untersuchen. (So weit möglich!)
 AnalyserPreferences.checkboxes.3.text=Nicht initialisierte Variablen feststellen.

--- a/src/lu/fisch/structorizer/locales/en.txt
+++ b/src/lu/fisch/structorizer/locales/en.txt
@@ -290,7 +290,7 @@ Menu.error07_1.text=«%» is not a valid name for a program or method!
 Menu.error07_2.text=«%» is not a valid name for a parameter!
 Menu.error07_3.text=«%» is not a valid name for a variable!
 Menu.error08.text=It is not allowed to make an assignment inside a condition.
-Menu.error09.text=Your program («%») cannot have the same name as a variable or parameter!
+Menu.error09.text=Your program («%») may not share its name with a variable or parameter!
 Menu.error10_1.text=A single instruction element should not contain input/output instructions and assignments!
 Menu.error10_2.text=A single instruction element should not contain input and output instructions!
 Menu.error10_3.text=A single instruction element should not contain input instructions and assignments!
@@ -722,6 +722,8 @@ Surface.msgUnsavedDiagrams.text=Couldn't save these diagrams:
 Surface.msgUnsavedHint.text=You might want to double-click and save them via Structorizer first.
 Surface.msgUnsavedContinue.text=Continue nevertheless?
 Surface.msgNoArrFile.text=No Arranger file found
+Surface.msgDefectiveArr.text=Defective arrangement.
+Surface.msgDefectiveArrz.text=Defective portable arrangement file.
 
 -----> Executor
 -----[ Control ]-----

--- a/src/lu/fisch/structorizer/locales/en.txt
+++ b/src/lu/fisch/structorizer/locales/en.txt
@@ -81,6 +81,7 @@
  *      Kay Gürtzig     2016.10.13      Enh. #270: Editor.popupDisable and InputBox.chkDisabled added.
  *      Kay Gürtzig     2016.10.16      Enh. #272: Menu.menuEditUpgradeTurtle, Menu.menuDowngradeTurtle added
  *      Kay Gürtzig     2016.11.08      Enh. #270: Editor.btnDisable.tooltip added
+ *      Kay Gürtzig     2016.11.10      Enh. #286: AnalyserPreferences tabs
  *
  ******************************************************************************************************
  *
@@ -318,6 +319,8 @@ Menu.error20.text=A subroutine header must have a (possibly empty) parameter lis
 
 -----[ AnalyserPreferences ]-----
 AnalyserPreferences.title=Analyser preferences
+AnalyserPreferences.contentPanel.tab.0=Algorithmic
+AnalyserPreferences.contentPanel.tab.1=Names / Conventions
 AnalyserPreferences.checkboxes.1.text=Check for modified loop variable.
 AnalyserPreferences.checkboxes.2.text=Check for endless loop (as far as detectable!)
 AnalyserPreferences.checkboxes.3.text=Check for non-initialized variables.

--- a/src/lu/fisch/structorizer/locales/es.txt
+++ b/src/lu/fisch/structorizer/locales/es.txt
@@ -85,6 +85,7 @@
  *      Kay Gürtzig     2016.10.16  Enh. #272: Menu.menuEditUpgradeTurtle, Menu.menuDowngradeTurtle added
  *      Kay Gürtzig     2016.10.18  several Analyser checks (among them 15, according to enh.#267) reformulated.
  *      Kay Gürtzig     2016.11.08  Enh. #270: Editor.btnDisable.tooltip added
+ *      Kay Gürtzig     2016.11.10  Enh. #286: AnalyserPreferences tabs
  *
  ******************************************************************************************************
  *
@@ -317,6 +318,8 @@ Menu.error20.text=El ecabezamiento de un subprograma debe tener un parénthesis 
 
 -----[ AnalyserPreferences ]-----
 AnalyserPreferences.title=Preferencias del Comprobador
+AnalyserPreferences.contentPanel.tab.0=Algorítmico
+AnalyserPreferences.contentPanel.tab.1=Nombres y convenciones
 AnalyserPreferences.checkboxes.1.text=Comprobar modificación de la variable del bucle.
 AnalyserPreferences.checkboxes.2.text=Comprobar bucle sin fin (¡en la medida de lo detectable!)
 AnalyserPreferences.checkboxes.3.text=Comprobar si hay variables no inicializadas.
@@ -567,10 +570,10 @@ Preferences.btnOK.tooltip=Aceptar los cambios.
 -----[ About ]-----
 About.title=Acerca de
 About.pnlTabbed.tab.0=Personas implicadas
-About.pnlTabbed.tab.1=Cambios
+About.pnlTabbed.tab.1=Diario de cambios
 About.pnlTabbed.tab.2=Licencia
 About.btnOK.text=Aceptar
-About.btnOK.tooltip=Aceptar los cambios.
+About.btnOK.tooltip=Cerrar el diálogo.
 
 
 -----[ FontChooser ]-----

--- a/src/lu/fisch/structorizer/locales/es.txt
+++ b/src/lu/fisch/structorizer/locales/es.txt
@@ -721,6 +721,8 @@ Surface.msgUnsavedDiagrams.text=Estos diagramas no fueron guardados:
 Surface.msgUnsavedHint.text=Para guardarlos por Structorizer anteriormente haz un doble clic a los diagramas.
 Surface.msgUnsavedContinue.text=¿Continuar aun así?
 Surface.msgNoArrFile.text=Ningún Arranger archivo encontrado
+Surface.msgDefectiveArr.text=Colocación defectuosa.
+Surface.msgDefectiveArrz.text=Archivo portable defectuoso.
 
 -----> Executor
 -----[ Control ]-----

--- a/src/lu/fisch/structorizer/locales/it.txt
+++ b/src/lu/fisch/structorizer/locales/it.txt
@@ -63,6 +63,7 @@
  *      Kay Gürtzig     2016.10.11      Enh. #267: Menu.error15 divided into error15_1 and error15_2
  *                                      Enh. #268: Sub-section OutputConsole added
  *      Kay Gürtzig     2016.11.08      Enh. #270: Menu.menuDiagramDisable, Editor.btnDisable.tooltip etc. added
+ *      Kay Gürtzig     2016.11.10      Enh. #286: AnalyserPreferences tabs; About tab translations modified
  *
  ******************************************************************************************************
  *
@@ -285,6 +286,8 @@ Menu.error20.text=
 
 -----[ AnalyserPreferences ]-----
 AnalyserPreferences.title=Preferenze dell'analizzatore
+AnalyserPreferences.contentPanel.tab.0=Algoritmico
+AnalyserPreferences.contentPanel.tab.1=Nomi e convenzioni
 AnalyserPreferences.checkboxes.1.text=Controlla variabile di ciclo modificata.
 AnalyserPreferences.checkboxes.2.text=Controlla cicli infiniti (finchè e rilevabile!)
 AnalyserPreferences.checkboxes.3.text=Controlla variabili non inizializzate.
@@ -519,7 +522,7 @@ Preferences.btnOK.tooltip=Valida le tue scelte.
 
 -----[ About ]-----
 About.title=About
-About.pnlTabbed.tab.0=Implicated Persons
+About.pnlTabbed.tab.0=Personi coinvolti
 About.pnlTabbed.tab.1=Changelog
 About.pnlTabbed.tab.2=Licenzi
 About.btnOK.text=OK

--- a/src/lu/fisch/structorizer/parsers/D7Parser.java
+++ b/src/lu/fisch/structorizer/parsers/D7Parser.java
@@ -1143,7 +1143,7 @@ public class D7Parser implements GPMessageConstants
 			_keyword = "";
 		}
 		// Bugfix #281/#282
-                if (keywordMap.containsKey(_key)) {
+		if (keywordMap.containsKey(_key)) {
 			keywordMap.put(_key, _keyword);
 		}
 	}


### PR DESCRIPTION
- Enh. #286: Analyser Preferences now organized into two tabs with groups
- Issue #81: Checkbox and radio button scaling implemented
- Issue #288: Radio button functionality fix in FOR loop editor
- Enh. #289: Arranger files (.arr, .arrz) may now be dragged into Arranger
- Enh. #290: Arranger files (.arr, .arrz) loadable from Structorizer, too
- Bugfix #291: REPEAT loops had caught cursor up traversal
- Bugfix #114: Prerequisites for editing and transmutation during execution revised
- Issue #269: Selecting an Analyser error now scrolls to the element
- Issue #269: Automatic scrolling to the element currently executed