### PR TITLE
Bugfix3.25 - version 3.25-08 candidate

### DIFF
--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -177,7 +177,7 @@ import javax.swing.ImageIcon;
 
 public abstract class Element {
 	// Program CONSTANTS
-	public static String E_VERSION = "3.25-07";
+	public static String E_VERSION = "3.25-08";
 	public static String E_THANKS =
 	"Developed and maintained by\n"+
 	" - Robert Fisch <robert.fisch@education.lu>\n"+

--- a/src/lu/fisch/structorizer/elements/Instruction.java
+++ b/src/lu/fisch/structorizer/elements/Instruction.java
@@ -51,6 +51,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.09.25      Enh. #253: D7Parser.keywordMap refactored
  *      Kay Gürtzig     2016.10.13      Enh. #270: Hatched overlay texture in draw() if disabled
  *      Kay Gürtzig     2016.10.15      Enh. #271: method isEmptyInput() had to consider prompt strings now.
+ *      Kay Gürtzig     2016.11.22      Bugfix #296: Wrong transmutation of return and output statements
  *
  ******************************************************************************************************
  *
@@ -366,9 +367,11 @@ public class Instruction extends Element {
 	
 	public static boolean isProcedureCall(String line)
 	{
-		// Be aware that this method is also used for the isFunctionCall check
-		Function fct = new Function(line);
-		return fct.isFunction();
+    	// START KGU#298 2016-11-22: Bugfix #296 - unawareness of had led to wrong transmutations
+		//Function fct = new Function(line);
+		//return fct.isFunction();
+		return !isJump(line) && !isOutput(line) && (new Function(line)).isFunction();
+    	// END KGU#298 2016-11-22
 	}
 	public boolean isProcedureCall()
 	{
@@ -391,8 +394,7 @@ public class Instruction extends Element {
 		int asgnPos = tokens.indexOf("<-");
 		if (asgnPos > 0)
 		{
-			// This looks somewhat misleading. But we do a mere syntax check
-			isFunc = isProcedureCall(tokens.concatenate("", asgnPos+1));
+			isFunc = (new Function(tokens.concatenate("", asgnPos+1))).isFunction();
 		}
 		return isFunc;
 	}

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -104,7 +104,8 @@ package lu.fisch.structorizer.executor;
  *      Kay Gürtzig     2016.10.16      Enh. #273: Input strings "true" and "false" now accepted as boolean values
  *                                      Bugfix #276: Raw string conversion and string display mended, undue replacements
  *                                      of ' into " in method convert() eliminated
- *      Kay Gürtzig     2016.11.19      Issue #269: Scrolling problem eventually solved. 
+ *      Kay Gürtzig     2016.11.19      Issue #269: Scrolling problem eventually solved.
+ *      Kay Gürtzig     2016.11.22      Bugfix #293: input and output boxes no longer popped up at odd places on screen. 
  *
  ******************************************************************************************************
  *
@@ -795,7 +796,7 @@ public class Executor implements Runnable
 					//		"Please enter a value for <" + in + ">", null);
 					String msg = control.lbInputValue.getText();
 					msg = msg.replace("%", in);
-					String str = JOptionPane.showInputDialog(null, msg, null);
+					String str = JOptionPane.showInputDialog(diagram.getParent(), msg, null);
 					// END KGU#89 2016-03-18
 					if (str == null)
 					{
@@ -886,7 +887,7 @@ public class Executor implements Runnable
 			//		JOptionPane.ERROR_MESSAGE);
 			if (!isErrorReported)
 			{
-				JOptionPane.showMessageDialog(diagram, result, control.msgTitleError.getText(),
+				JOptionPane.showMessageDialog(diagram.getParent(), result, control.msgTitleError.getText(),
 						JOptionPane.ERROR_MESSAGE);
 				// START KGU#160 2016-07-27: Issue #137 - also log the result to the console
 				this.console.writeln("*** " + result, Color.RED);
@@ -956,7 +957,7 @@ public class Executor implements Runnable
 									// START KGU#160 2016-04-26: Issue #137 - also log the result to the console
 									this.console.writeln("*** " + header + ": " + this.prepareValueForDisplay(resObj), Color.CYAN);
 									// END KGU#160 2016-04-26
-									JOptionPane.showMessageDialog(diagram, resObj,
+									JOptionPane.showMessageDialog(diagram.getParent(), resObj,
 											header, JOptionPane.INFORMATION_MESSAGE);
 								}
 								else
@@ -965,7 +966,7 @@ public class Executor implements Runnable
 									this.console.writeln("*** " + header + ": " + this.prepareValueForDisplay(resObj), Color.CYAN);
 									// END KGU#198 2016-05-25
 									Object[] options = {"OK", "Pause"};		// FIXME: Provide a translation
-									int pressed = JOptionPane.showOptionDialog(diagram, resObj, header,
+									int pressed = JOptionPane.showOptionDialog(diagram.getParent(), resObj, header,
 											JOptionPane.OK_CANCEL_OPTION, JOptionPane.INFORMATION_MESSAGE, null, options, null);
 									if (pressed == 1)
 									{
@@ -2463,7 +2464,7 @@ public class Executor implements Runnable
 		{
 			// In run mode, give the user a chance to intervene
 			Object[] options = {"OK", "Pause"};	// FIXME: Provide a translation
-			int pressed = JOptionPane.showOptionDialog(diagram, control.lbAcknowledge.getText(), control.lbInput.getText(),
+			int pressed = JOptionPane.showOptionDialog(diagram.getParent(), control.lbAcknowledge.getText(), control.lbInput.getText(),
 					JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, null);
 			if (pressed == 1)
 			{
@@ -2526,7 +2527,7 @@ public class Executor implements Runnable
 				this.console.setVisible(true);
 			}
 			// END KGU#160 2016-04-12
-			String str = JOptionPane.showInputDialog(null, prompt, null);
+			String str = JOptionPane.showInputDialog(diagram.getParent(), prompt, null);
 			// END KGU#89 2016-03-18
 			// START KGU#84 2015-11-23: ER #36 - Allow a controlled continuation on cancelled input
 			//setVarRaw(in, str);
@@ -2536,7 +2537,7 @@ public class Executor implements Runnable
 				// START KGU#197 2016-05-05: Issue #89
 				//JOptionPane.showMessageDialog(diagram, "Execution paused - you may enter the value in the variable display.",
 				//		"Input cancelled", JOptionPane.WARNING_MESSAGE);
-				JOptionPane.showMessageDialog(diagram, control.lbInputPaused.getText(),
+				JOptionPane.showMessageDialog(control, control.lbInputPaused.getText(),
 						control.lbInputCancelled.getText(), JOptionPane.WARNING_MESSAGE);
 				// START KGU#197 2016-05-05
 				synchronized(this)
@@ -2634,14 +2635,16 @@ public class Executor implements Runnable
 			// END KGU#160 2016-04-12
 			{
 				// In step mode, there is no use to offer pausing
-				JOptionPane.showMessageDialog(diagram, s, control.lbOutput.getText(),
+				// diagram is a bad anchor component since its extension is the Root rectangle (may be huge!)
+				JOptionPane.showMessageDialog(diagram.getParent(), s, control.lbOutput.getText(),
 						JOptionPane.INFORMATION_MESSAGE);
 			}
 			else
 			{
 				// In run mode, give the user a chance to intervene
 				Object[] options = {"OK", "Pause"};	// FIXME: Provide a translation
-				int pressed = JOptionPane.showOptionDialog(diagram, s, control.lbOutput.getText(),
+				// diagram is a bad anchor component since its extension is the Root rectangle (may be huge!)
+				int pressed = JOptionPane.showOptionDialog(diagram.getParent(), s, control.lbOutput.getText(),
 						JOptionPane.OK_CANCEL_OPTION, JOptionPane.INFORMATION_MESSAGE, null, options, null);
 				if (pressed == 1)
 				{
@@ -2700,7 +2703,7 @@ public class Executor implements Runnable
 					//String s = unconvert(resObj.toString());
 					//JOptionPane.showMessageDialog(diagram, s,
 					//		"Returned result", JOptionPane.INFORMATION_MESSAGE);
-					JOptionPane.showMessageDialog(diagram, resObj,
+					JOptionPane.showMessageDialog(diagram.getParent(), resObj,
 							header, JOptionPane.INFORMATION_MESSAGE);
 					// END KGU#147 2016-01-29					
 				// END KGU#133 2016-01-29
@@ -2711,7 +2714,7 @@ public class Executor implements Runnable
 					// END KGU#198 2016-05-25
 					// START KGU#84 2015-11-23: Enhancement to give a chance to pause (though of little use here)
 					Object[] options = {"OK", "Pause"};		// FIXME: Provide a translation
-					int pressed = JOptionPane.showOptionDialog(diagram, resObj, header,
+					int pressed = JOptionPane.showOptionDialog(diagram.getParent(), resObj, header,
 							JOptionPane.OK_CANCEL_OPTION, JOptionPane.INFORMATION_MESSAGE, null, options, null);
 					if (pressed == 1)
 					{
@@ -3725,7 +3728,7 @@ public class Executor implements Runnable
 						//JOptionPane.showMessageDialog(diagram, "Uncaught attempt to jump out of a parallel thread:\n\n" + 
 						//		instr.getText().getText().replace("\n",  "\n\t") + "\n\nThread killed!",
 						//		"Parallel Execution Problem", JOptionPane.WARNING_MESSAGE);
-						JOptionPane.showMessageDialog(diagram, control.msgJumpOutParallel.getText().replace("%", "\n\n" + 
+						JOptionPane.showMessageDialog(diagram.getParent(), control.msgJumpOutParallel.getText().replace("%", "\n\n" + 
 								instr.getText().getText().replace("\n",  "\n\t") + "\n\n"),
 								control.msgTitleParallel.getText(), JOptionPane.WARNING_MESSAGE);
 						// END KGU#247 2016-09-17

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -105,7 +105,7 @@ package lu.fisch.structorizer.executor;
  *                                      Bugfix #276: Raw string conversion and string display mended, undue replacements
  *                                      of ' into " in method convert() eliminated
  *      Kay Gürtzig     2016.11.19      Issue #269: Scrolling problem eventually solved.
- *      Kay Gürtzig     2016.11.22      Bugfix #293: input and output boxes no longer popped up at odd places on screen. 
+ *      Kay Gürtzig     2016.11.22      Bugfix #293: input and output boxes no longer popped up at odd places on screen.
  *
  ******************************************************************************************************
  *
@@ -994,6 +994,11 @@ public class Executor implements Runnable
 				}
 
 			}
+			// START KGU#299 2016-11-23: Enh. #297 In step mode, this offers a last pause to inspect variables etc.
+			if (this.callers.isEmpty() && !returned) {
+				delay();
+			}
+			// END KGU 2016-11-23
 
 		}
 		// START KGU 2015-10-13: Unsets all execution flags in the diagram
@@ -2873,6 +2878,7 @@ public class Executor implements Runnable
 				if ((q == last)
 						&& !text.get(text.count() - 1).trim().equals("%"))
 				{
+					// default branch
 					go = true;
 				}
 				if (go == false)

--- a/src/lu/fisch/structorizer/executor/Executor.java
+++ b/src/lu/fisch/structorizer/executor/Executor.java
@@ -493,6 +493,7 @@ public class Executor implements Runnable
 
 		if (convertComparisons)
 		{
+			// FIXME: This should only be applied to an expression in s, not to an entire instruction line!
 			s = convertStringComparison(s);
 		}
 

--- a/src/lu/fisch/structorizer/executor/OutputConsole.java
+++ b/src/lu/fisch/structorizer/executor/OutputConsole.java
@@ -39,6 +39,7 @@ package lu.fisch.structorizer.executor;
  *      Kay Gürtzig     2016.09.25      Bugfix #251 averting Nimbus disrespect of panel settings 
  *      Kay Gürtzig     2016.10.11      Enh. #268: Inheritance changed, font selecting opportunities added
  *      Kay Gürtzig     2016.10.17      Issue #268: Font setting source and target corrected (doc's default style)
+ *      Kay Gürtzig     2016.11.22      Enh.#284: Font resizing accelerators modified (CTRL_DOWN_MASK added)
  *
  ******************************************************************************************************
  *
@@ -51,6 +52,7 @@ import java.awt.Color;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 
 import javax.swing.JMenu;
@@ -114,10 +116,10 @@ public class OutputConsole extends LangFrame implements ActionListener {
     	menuFont.addActionListener(this);
     	menuFontUp = new JMenuItem("Enlarge font", IconLoader.ico033);
     	menuFontUp.addActionListener(this);
-    	menuFontUp.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_ADD, 0));
+    	menuFontUp.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_ADD, InputEvent.CTRL_DOWN_MASK));
     	menuFontDown = new JMenuItem("Diminish font", IconLoader.ico034);
     	menuFontDown.addActionListener(this);
-    	menuFontDown.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_SUBTRACT, 0));
+    	menuFontDown.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_SUBTRACT, InputEvent.CTRL_DOWN_MASK));
     	
     	JMenuBar menuBar = new JMenuBar();
     	menuBar.add(menu);

--- a/src/lu/fisch/structorizer/generators/BasGenerator.java
+++ b/src/lu/fisch/structorizer/generators/BasGenerator.java
@@ -54,6 +54,7 @@ package lu.fisch.structorizer.generators;
  *      Kay Gürtzig         2016.10.13      Enh. #270: Handling of disabled elements added.
  *      Kay Gürtzig         2016.10.15      Enh. #271: Support for input instructions with prompt
  *      Kay Gürtzig         2016.10.16      Enh. #274: Colour info for Turtleizer procedures added
+ *      Kay Gürtzig         2016.11.20      KGU#293: Some forgotten traditional keywords added to reservedWords (#231)
  *
  ******************************************************************************************************
  *
@@ -132,6 +133,9 @@ public class BasGenerator extends Generator
 		"FOR", "TO", "STEP", "NEXT",
 		"DO", "WHILE", "UNTIL", "LOOP",
 		"CALL", "RETURN", "GOTO", "GOSUB", "STOP",
+		// START KGU#293 2016-11-20
+		"INPUT", "PRINT", "READ", "DATA", "RESTORE",
+		// END KGU#293 2016-11-20
 		"AND", "OR", "NOT"};
 	public String[] getReservedWords()
 	{

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -103,6 +103,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.11.16      Bugfix #291: upward cursor traversal ended in REPEAT loops
  *      Kay Gürtzig     2016.11.17      Bugfix #114: Prerequisites for editing and transmutation during execution revised
  *      Kay Gürtzig     2016.11.18/19   Issue #269: Scroll to the element associated to a selected Analyser error
+ *      Kay Gürtzig     2016.11.21      Issue #269: Focus alignment improved for large elements
  *
  ******************************************************************************************************
  *
@@ -906,16 +907,26 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
     public void redraw(Element element)
     {
     	Rectangle rect = element.getRectOffDrawPoint().getRectangle();
-    	// START KGU#276 2016-11-19: Issue #269 Ensure the element is shown left-bound
-    	if (!(element instanceof Alternative || element instanceof Case))
+    	Rectangle visibleRect = new Rectangle();
+    	this.computeVisibleRect(visibleRect);
+    	// START KGU#276 2016-11-19: Issue #269 Ensure wide elements be shown left-bound
+    	if (rect.width > visibleRect.width &&
+    			!(element instanceof Alternative || element instanceof Case))
     	{
-    		Rectangle visibleRect = new Rectangle();
-    		this.computeVisibleRect(visibleRect);
-    		if (rect.width > visibleRect.width) {
-    			rect.width = visibleRect.width;
-    		}
+    		rect.width = visibleRect.width;
     	}
     	// END KGU#276 2016-11-19
+    	// START KGU#276 2016-11-21: Issue #269 Ensure high elements be shown top-bound
+    	if (rect.height > visibleRect.height &&
+    			!(element instanceof Instruction || element instanceof Parallel || element instanceof Forever))
+    	{
+    		// ... except for REPEAT loops, which are to be shown bottom-aligned
+    		if (element instanceof Repeat)	{
+    			rect.y += rect.height - visibleRect.height;
+    		}
+    		rect.height = visibleRect.height;
+    	}
+    	// END KGU#276 2016-11-21
     	scrollRectToVisible(rect);
     	redraw();	// This is to make sure the drawing rectangles are correct
     }

--- a/src/lu/fisch/structorizer/gui/Editor.java
+++ b/src/lu/fisch/structorizer/gui/Editor.java
@@ -47,6 +47,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.08.02      Enh. #215: popupBreakTrigger added
  *      Kay Gürtzig     2016.10.13      Enh. #277: New toolbar button (+ context menu item) for disabling elements
  *      Kay Gürtzig     2016.11.17      Bugfix #114: Prerequisites for editing and transmutation during execution revised
+ *      Kay Gürtzig     2016.11.22      Enh. #284: Key bindings for font resizing added (KGU#294)
  *
  ******************************************************************************************************
  *
@@ -288,6 +289,28 @@ public class Editor extends LangPanel implements NSDController, ComponentListene
     	
     }
     // END KGU#177 2016-04-14
+    // START KGU#294 2016-11-22: Issue #284 Unification of font resizing key bindings
+    private class FontResizeAction extends AbstractAction
+    {
+    	Diagram diagram;	// The object responsible for executing the action
+    	
+    	FontResizeAction(Diagram _diagram, String _key)
+    	{
+    		super(_key);
+    		diagram = _diagram;
+    	}
+    	
+		@Override
+		public void actionPerformed(ActionEvent ev) {
+			if (getValue(AbstractAction.NAME).equals("FONT_UP")) {
+				diagram.fontUpNSD();
+			}
+			else {
+				diagram.fontDownNSD();	
+			}
+		}
+    }
+    // END KGU#294 2016-11-22
     
     private MyToolbar newToolBar(String name)
     {
@@ -726,6 +749,10 @@ public class Editor extends LangPanel implements NSDController, ComponentListene
 		inpMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_DOWN, 0), "PAGE_DOWN");
 		inpMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_PAGE_UP, 0), "PAGE_UP");
 		// END KGU#177 2016-04-16
+	    // START KGU#294 2016-11-22: Enh. #284
+		inpMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ADD, InputEvent.CTRL_DOWN_MASK), "FONT_UP");
+		inpMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_SUBTRACT, InputEvent.CTRL_DOWN_MASK), "FONT_DOWN");
+		// END KGU#294 2016-11-22
 		actMap.put(CursorMoveDirection.CMD_UP, new SelectionMoveAction(diagram, CursorMoveDirection.CMD_UP));
 		actMap.put(CursorMoveDirection.CMD_DOWN, new SelectionMoveAction(diagram, CursorMoveDirection.CMD_DOWN));
 		actMap.put(CursorMoveDirection.CMD_LEFT, new SelectionMoveAction(diagram, CursorMoveDirection.CMD_LEFT));
@@ -739,6 +766,10 @@ public class Editor extends LangPanel implements NSDController, ComponentListene
 		actMap.put("PAGE_DOWN", new PageScrollAction(scrollarea.getVerticalScrollBar(), false, "PAGE_DOWN"));
 		actMap.put("PAGE_UP", new PageScrollAction(scrollarea.getVerticalScrollBar(), true, "PAGE_UP"));
 		// END KGU#177 2016-04-16
+		// START KGU#294 2016-11-22: Enh. #284
+		actMap.put("FONT_DOWN", new FontResizeAction(diagram, "FONT_DOWN"));
+		actMap.put("FONT_UP", new FontResizeAction(diagram, "FONT_UP"));
+		// END KGU#294 2016-11-22
 		//scrollarea.getViewport().setBackingStoreEnabled(true);
 				
         //container.add(scrolllist,AKDockLayout.SOUTH);

--- a/src/lu/fisch/structorizer/gui/InputBox.java
+++ b/src/lu/fisch/structorizer/gui/InputBox.java
@@ -45,6 +45,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.11.02  Issue #81: Workaround for lacking DPI awareness
  *      Kay Gürtzig     2016.11.09  Issue #81: Scale factor no longer rounded but ensured to be >= 1
  *      Kay Gürtzig     2016.11.11  Issue #81: DPI-awareness workaround for checkboxes
+ *      Kay Gürtzig     2016.11.21  Issue #284: Opportunity to scale up/down the TextField fonts by Ctrl-Numpad+/-
  *
  ******************************************************************************************************
  *
@@ -58,6 +59,7 @@ import lu.fisch.structorizer.locales.LangDialog;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.util.Vector;
 
 import javax.swing.*;
 import javax.swing.border.*;
@@ -110,6 +112,11 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
         setSize((int)(500 * scaleFactor), (int)(400 * scaleFactor));        
     }
     // END KGU#287 2016-11-02
+    
+    // START KGU#294 2016-11-21: Issue #284
+    // Components with fonts to be scaled independently 
+    protected Vector<JComponent> scalableComponents = new Vector<JComponent>();
+    // END KGU#294 2016-11-21
 
     private void create() {
         // set window title
@@ -165,6 +172,11 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
         Border emptyBorder = BorderFactory.createEmptyBorder(border, border, border, border);
         txtText.setBorder(emptyBorder);
         txtComment.setBorder(emptyBorder);
+        
+        // START KGU#294 2016-11-21: Issue #284
+        scalableComponents.addElement(txtText);
+        scalableComponents.addElement(txtComment);
+        // END KGU#294 2016-11-21
         
         JPanel pnPanel0 = new JPanel();
         GridBagLayout gbPanel0 = new GridBagLayout();
@@ -375,6 +387,19 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
             OK = true;
             setVisible(false);
         }
+        // START KGU#294 2016-11-21: Issue #284 - Opportunity to modify JTextField font size
+        else if ((e.getKeyCode() == KeyEvent.VK_ADD || e.getKeyCode() == KeyEvent.VK_SUBTRACT) && (e.isControlDown())) {
+        	Font font = txtText.getFont();
+        	float increment = 2.0f;
+        	if (e.getKeyCode() == KeyEvent.VK_SUBTRACT) {
+        		increment = font.getSize() > 8 ? -2.0f : 0.0f;
+        	}
+        	Font newFont = font.deriveFont(font.getSize()+increment);
+        	for (JComponent comp: scalableComponents) {
+        		comp.setFont(newFont);
+        	}
+        }
+        // END KGU#294 2016-11-21
     }
     
     @Override

--- a/src/lu/fisch/structorizer/gui/InputBox.java
+++ b/src/lu/fisch/structorizer/gui/InputBox.java
@@ -101,6 +101,11 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
     public LangTextHolder lblBreakTrigger = new LangTextHolder("0");
     //public JTextField txtBreakTrigger = new JTextField();
     // END KGU#213 2016-08-01
+    
+    // START KGU#294 2016-11-22: Enh. #284
+    protected final JButton btnFontUp = new JButton(IconLoader.ico033); 
+    protected final JButton btnFontDown = new JButton(IconLoader.ico034);
+    // END KGI#294 2016-11-22
 
     // START KGU 2015-10-14: Additional information for data-specific title translation
     public String elementType = new String();	// The (lower-case) class name of the element type to be edited here
@@ -147,12 +152,16 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
         setVisible(false);
         // set action to perform if closed
         setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-        // set icon
+        // set listeners
+        // START KGU#294 2016-11-22: Issue #284
+        btnFontUp.addActionListener(this);
+        btnFontDown.addActionListener(this);
+        // END KGU#294 2016-11-22
         btnOK.addActionListener(this);
         btnCancel.addActionListener(this);
         
-        btnOK.addKeyListener(this);
-        btnCancel.addKeyListener(this);
+        btnOK.addKeyListener(this);		// ???
+        btnCancel.addKeyListener(this);	// ???
         txtText.addKeyListener(this);
         // START KGU#186 2016-04-26: Issue #163 - tab isn't really needed within the text
         txtText.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, null);
@@ -240,6 +249,23 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
         gbPanel1.setConstraints(chkDisabled, gbcPanel1);
         pnPanel1.add(chkDisabled);
         // END KGU#277 2016-10-13
+        
+        // START KGU#294 2016-11-22: Issue #284 - visible font-resizing buttons
+        JPanel fontPanel = new JPanel();
+        fontPanel.setLayout(new GridLayout(0,2));
+        fontPanel.add(btnFontUp);
+        fontPanel.add(btnFontDown);
+        gbcPanel1.gridx = 12;
+        gbcPanel1.gridy = 17;
+        gbcPanel1.gridwidth = 7;
+        gbcPanel1.gridheight = 1;
+        gbcPanel1.fill = GridBagConstraints.WEST;
+        gbcPanel1.weightx = 1;
+        gbcPanel1.weighty = 0;
+        gbcPanel1.anchor = GridBagConstraints.EAST;
+        gbPanel1.setConstraints(fontPanel, gbcPanel1);
+        pnPanel1.add(fontPanel);
+        // END KGU#294 2016-11-22
 
         gbcPanel1.gridx = 1;
         // START KGU#277 2016-10-13: Enh. #270
@@ -371,6 +397,12 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
         } else if (source == btnCancel) {
             OK = false;
         }
+        // START KGU#294 2016-11-22: Issue #284
+        else if (source == btnFontUp || source == btnFontDown) {
+        	fontControl(source == btnFontUp);
+        	return;
+        }
+        // END KGU#294 2016-11-22
         setVisible(false);
     }
     
@@ -389,15 +421,7 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
         }
         // START KGU#294 2016-11-21: Issue #284 - Opportunity to modify JTextField font size
         else if ((e.getKeyCode() == KeyEvent.VK_ADD || e.getKeyCode() == KeyEvent.VK_SUBTRACT) && (e.isControlDown())) {
-        	Font font = txtText.getFont();
-        	float increment = 2.0f;
-        	if (e.getKeyCode() == KeyEvent.VK_SUBTRACT) {
-        		increment = font.getSize() > 8 ? -2.0f : 0.0f;
-        	}
-        	Font newFont = font.deriveFont(font.getSize()+increment);
-        	for (JComponent comp: scalableComponents) {
-        		comp.setFont(newFont);
-        	}
+        	fontControl(e.getKeyCode() == KeyEvent.VK_ADD);
         }
         // END KGU#294 2016-11-21
     }
@@ -457,5 +481,20 @@ public class InputBox extends LangDialog implements ActionListener, KeyListener 
     	this.lblBreakTriggerText.setText(this.lblBreakTriggerText.getText().replace("%", lblBreakTrigger.getText()));
     }
     // END KGU#246 2016-09-21
+    
+    // START KGU#294 2016-11-22: Issue #284
+    public void fontControl(boolean up)
+    {
+    	Font font = txtText.getFont();
+    	float increment = 2.0f;
+    	if (!up) {
+    		increment = font.getSize() > 8 ? -2.0f : 0.0f;
+    	}
+    	Font newFont = font.deriveFont(font.getSize()+increment);
+    	for (JComponent comp: scalableComponents) {
+    		comp.setFont(newFont);
+    	}
+    }
+    // END KGU#294 2016-11-22
 
 }

--- a/src/lu/fisch/structorizer/gui/InputBoxFor.java
+++ b/src/lu/fisch/structorizer/gui/InputBoxFor.java
@@ -45,6 +45,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.11.11  Issue #81: DPI-awareness workaround for checkboxes/radio buttons,
  *                                  Bugfix #288: Behaviour on clicking the selected one of the radio buttons fixed
  *      Kay Gürtzig     2016.11.21  Issue #284: Opportunity to scale up/down the TextField fonts by Ctrl-Numpad+/-
+ *      Kay Gürtzig     2016.11.22  stepFor label mended; issue #284: Font resizing buttons added
  *
  ******************************************************************************************************
  *
@@ -188,7 +189,7 @@ public class InputBoxFor extends InputBox implements ItemListener {
 		//lblPreFor = new JLabel(D7Parser.keywordMap.get("preFor"));
 		lblPostFor = new JLabel(D7Parser.getKeyword("postFor"));
 		lblAsgnmt = new JLabel(" <- ");
-		lblStepFor = new JLabel(D7Parser.getKeyword("steptFor"));
+		lblStepFor = new JLabel(D7Parser.getKeyword("stepFor"));
 		txtParserInfo = new JTextField(300);
 		txtParserInfo.setEditable(false);
 		if (UIManager.getLookAndFeel().getName().equals("Nimbus"))
@@ -237,6 +238,10 @@ public class InputBoxFor extends InputBox implements ItemListener {
 		scalableComponents.addElement(txtIncr);
 		scalableComponents.addElement(txtVariableIn);
 		scalableComponents.addElement(txtValueList);
+		scalableComponents.addElement(lblAsgnmt);
+		scalableComponents.addElement(lblPostFor);
+		scalableComponents.addElement(lblStepFor);
+		scalableComponents.addElement(lblpostForIn);		
         // END KGU#294 2016-11-21
 		
 		// START KGU#254 2016-09-24: Enh. #250 - GUI redesign

--- a/src/lu/fisch/structorizer/gui/InputBoxFor.java
+++ b/src/lu/fisch/structorizer/gui/InputBoxFor.java
@@ -44,6 +44,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.11.09  Issue #81: Scale factor no longer rounded but ensured to be >= 1
  *      Kay Gürtzig     2016.11.11  Issue #81: DPI-awareness workaround for checkboxes/radio buttons,
  *                                  Bugfix #288: Behaviour on clicking the selected one of the radio buttons fixed
+ *      Kay Gürtzig     2016.11.21  Issue #284: Opportunity to scale up/down the TextField fonts by Ctrl-Numpad+/-
  *
  ******************************************************************************************************
  *
@@ -228,6 +229,15 @@ public class InputBoxFor extends InputBox implements ItemListener {
         // END KGU#287 2016-11-11
 		chkTextInput.addItemListener(this);
 		txtText.addKeyListener(this);
+		
+        // START KGU#294 2016-11-21: Issue #284
+		scalableComponents.addElement(txtVariable);
+		scalableComponents.addElement(txtStartVal);
+		scalableComponents.addElement(txtEndVal);
+		scalableComponents.addElement(txtIncr);
+		scalableComponents.addElement(txtVariableIn);
+		scalableComponents.addElement(txtValueList);
+        // END KGU#294 2016-11-21
 		
 		// START KGU#254 2016-09-24: Enh. #250 - GUI redesign
 		rbCounting = new JRadioButton(D7Parser.getKeyword("preFor"));

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -5,7 +5,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-07 (2016.11.19)
+Current development version: 3.25-08 (2016.11.22)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -62,6 +62,10 @@ Current development version: 3.25-07 (2016.11.19)
 - 07: Bugfix #114: Prerequisites for editing and transmutation during execution revised <2>
 - 07: Issue #269: Selecting an Analyser error now scrolls to the element <2>
 - 07: Issue #269: Automatic scrolling to the element currently executed <2>
+- 08: Issue #231: Traditional reserved BASIC words added to name collision checks <2>
+- 08: Issue #269: Vertical scrolling alignment for large elements improved <2>
+- 08: Issue #284: Element editor fonts now up/down-scalable by Ctrl-Numpad+/- [ebial]2
+- 08: Bugfix #293: Input and output boxes no longer popped up at odd places on screen <2>
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -5,7 +5,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-08 (2016.11.23)
+Current development version: 3.25-08 (2016.11.24)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -64,8 +64,10 @@ Current development version: 3.25-08 (2016.11.22)
 - 07: Issue #269: Automatic scrolling to the element currently executed <2>
 - 08: Issue #231: Traditional reserved BASIC words added to name collision checks <2>
 - 08: Issue #269: Vertical scrolling alignment for large elements improved <2>
-- 08: Issue #284: Element editor fonts now up/down-scalable by Ctrl-Numpad+/- [ebial]2
+- 08: Issue #284: Text field fonts in element editor now interactively resizable [ebial]2
 - 08: Bugfix #293: Input and output boxes no longer popped up at odd places on screen <2>
+- 08: Font resizing accelerators unified among different dialogs and menus <2>
+- 08: Label defect in InputBoxFor (FOOR loop editor) mended <2>
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -65,7 +65,7 @@ Current development version: 3.25-08 (2016.11.24)
 - 08: Issue #231: Traditional reserved BASIC words added to name collision checks <2>
 - 08: Issue #269: Vertical scrolling alignment for large elements improved <2>
 - 08: Issue #284: Text field fonts in element editor now interactively resizable [ebial]2
-- 08: Bugfix #293: Input and output boxes no longer popped up at odd places on screen <2>
+- 08: Bugfix #293: Input and output boxes no longer pop up at odd places on screen <2>
 - 08: Font resizing accelerators unified among different dialogs and menus <2>
 - 08: Label defect in FOR loop editor (class InputBoxFor) mended <2>
 - 08: Bugfix #294: Test coverage wasn't shown for CASE elements w/o default branch <2>

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -5,7 +5,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-08 (2016.11.22)
+Current development version: 3.25-08 (2016.11.23)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -67,7 +67,10 @@ Current development version: 3.25-08 (2016.11.22)
 - 08: Issue #284: Text field fonts in element editor now interactively resizable [ebial]2
 - 08: Bugfix #293: Input and output boxes no longer popped up at odd places on screen <2>
 - 08: Font resizing accelerators unified among different dialogs and menus <2>
-- 08: Label defect in InputBoxFor (FOOR loop editor) mended <2>
+- 08: Label defect in FOR loop editor (class InputBoxFor) mended <2>
+- 08: Bugfix #294: Test coverage wasn't shown for CASE elements w/o default branch <2>
+- 08: Bugfix #295: Spurious Analyser warning "wrong assignment" in return statements <2>
+- 08: Bugfix #296: Wrong transmutation of return or output instructions <2>
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -71,6 +71,7 @@ Current development version: 3.25-08 (2016.11.23)
 - 08: Bugfix #294: Test coverage wasn't shown for CASE elements w/o default branch <2>
 - 08: Bugfix #295: Spurious Analyser warning "wrong assignment" in return statements <2>
 - 08: Bugfix #296: Wrong transmutation of return or output instructions <2>
+- 08: Enh. #297: Additional pause after a diagram's last instruction in step mode <2> 
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2


### PR DESCRIPTION
- Issue #231: Traditional reserved BASIC words added to name collision checks
- Issue #269: Vertical scrolling alignment for large elements improved
- Issue #284: Text field fonts in element editor now interactively resizable
- Bugfix #293: Input and output boxes no longer pop up at odd places on screen
- Font resizing accelerators unified among different dialogs and menus
- Label defect in FOR loop editor (class InputBoxFor) mended
- Bugfix #294: Test coverage wasn't shown for CASE elements w/o default branch
- Bugfix #295: Spurious Analyser warning "wrong assignment" in return statements
- Bugfix #296: Wrong transmutation of return or output instructions
- Enh. #297: Additional pause after a diagram's last instruction in step mode