### PR TITLE
Bugfix3.25 -> version 3.25-10 candidate

### DIFF
--- a/src/lu/fisch/structorizer/arranger/Arranger.java
+++ b/src/lu/fisch/structorizer/arranger/Arranger.java
@@ -53,6 +53,7 @@ package lu.fisch.structorizer.arranger;
  *      Kay Gürtzig     2016.09.26  Enh. #253: New public method getAllRoots() added.
  *      Kay Gürtzig     2016.11.01  Enh. #81: Scalability of the Icons ensured
  *      Kay Gürtzig     2016.11.15  Enh. #290: New opportunity to load arrangements from Structorizer
+ *      Kay Gürtzig     2016.12.12  Enh. #305: Support for diagram list in Structorizer 
  *
  ******************************************************************************************************
  *
@@ -87,7 +88,6 @@ import lu.fisch.structorizer.locales.LangFrame;
 public class Arranger extends LangFrame implements WindowListener, KeyListener, IRoutinePool {
 
     // START KGU#177 2016-04-14: Enh. #158 - because of pasting opportunity we must take more care
-
     private boolean isStandalone = false;
 	// END KGU#177 2016-04-14
 
@@ -130,6 +130,21 @@ public class Arranger extends LangFrame implements WindowListener, KeyListener, 
         return mySelf != null;
     }
 	// END KGU#155 2016-03-08
+    
+    // START KGU#305 2016-12-12: Enh. #305
+	/**
+	 * Scrolls to the given Root if found and selects it. If setAtTop is true then the diagram
+	 * will be raised to the top drawing level.
+	 * @param aRoot - the diagram to be focused
+	 * @param setAtTop - whether the diagram is to be drawn on top of all
+	 */
+    public static void scrollToDiagram(Root selectedRoot, boolean raiseToTop)
+    {
+    	if (mySelf != null && selectedRoot != null) {
+    		mySelf.surface.scrollToDiagram(selectedRoot, raiseToTop);
+    	}
+	}
+    // END KGU#305 2016-12-12
 
     /**
      * Creates new form Arranger
@@ -633,5 +648,16 @@ public class Arranger extends LangFrame implements WindowListener, KeyListener, 
         surface.repaint();
     }
 	// END KGU#156 2016-03-10
-    
+
+    // START KGU#305 2016-12-12: Enh. #305
+	/**
+	 * Returns the Root diagram currently selected in Arranger
+	 * @return Either a Root object or null (if none was selected)
+	 */
+	public Root getSelected() 
+	{
+		return surface.getSelected();
+	}
+	// END KGU#305 2016-12-12
+
 }

--- a/src/lu/fisch/structorizer/arranger/Diagram.java
+++ b/src/lu/fisch/structorizer/arranger/Diagram.java
@@ -20,6 +20,30 @@
 
 package lu.fisch.structorizer.arranger;
 
+/*
+ *****************************************************************************************************
+ *
+ *      Author: Bob Fisch
+ *
+ *      Description: This class is just a holder for diagrams, their owners, and positions within Arranger
+ *
+ ******************************************************************************************************
+ *
+ *      Revision List
+ *
+ *      Author          Date        Description
+ *      ------          ----        -----------
+ *      Bob Fisch       2009.08.18  First Issue
+ *      Kay Gürtzig     2015.11.24  Pinning flag added (issue #35, KGU#88)
+ *      Kay Gürtzig     2016.03.08  Bugfix #97: Method resetDrawingInfo added (KGU#155)
+ *
+ ******************************************************************************************************
+ *
+ * Comment:	/
+ *
+ *****************************************************************************************************
+ *///
+
 import java.awt.Point;
 import lu.fisch.structorizer.elements.Root;
 import lu.fisch.structorizer.gui.Mainform;
@@ -65,4 +89,5 @@ public class Diagram
 //		}
 	}
 	// END KGU#155 2016-03-08
+	
 }

--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -72,6 +72,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.09.28      KGU#264: Font name property renamed from "Name" to "Font".
  *      Kay Gürtzig     2016.10.13      Issue #270: New field "disabled" for execution and code export
  *      Kay Gürtzig     2016.11.06      Issue #279: Several modifications to circumvent direct access to D7Parser.keywordMap
+ *      Kay Gürtzig     2016.12.12      Enh. #305: New scrollList flag E_ARRANGER_INDEX for Arranger index
  *
  ******************************************************************************************************
  *
@@ -301,6 +302,9 @@ public abstract class Element {
 	// END KGU#227 2016-07-29
 	public static boolean E_DIN = false;			// Show FOR loops according to DIN 66261?
 	public static boolean E_ANALYSER = true;		// Analyser enabled?
+	// START KGU#305 2016-12-12: Enh. #305 (FIXME Still not used)
+	public static boolean E_ARRANGER_INDEX = false;	// Arranger index visible?
+	// END KGU#305 2016-12-12
 	// START KGU#123 2016-01-04: New toggle for Enh. #87
 	public static boolean E_WHEELCOLLAPSE = false;	// Is collapsing by mouse wheel rotation enabled?
 	// END KGU#123 2016-01-04

--- a/src/lu/fisch/structorizer/elements/Element.java
+++ b/src/lu/fisch/structorizer/elements/Element.java
@@ -177,7 +177,7 @@ import javax.swing.ImageIcon;
 
 public abstract class Element {
 	// Program CONSTANTS
-	public static String E_VERSION = "3.25-09";
+	public static String E_VERSION = "3.25-10";
 	public static String E_THANKS =
 	"Developed and maintained by\n"+
 	" - Robert Fisch <robert.fisch@education.lu>\n"+

--- a/src/lu/fisch/structorizer/elements/Repeat.java
+++ b/src/lu/fisch/structorizer/elements/Repeat.java
@@ -48,6 +48,7 @@ package lu.fisch.structorizer.elements;
  *      Kay Gürtzig     2016.04.24      Issue #169: Method findSelected() introduced, copy() modified (KGU#183)
  *      Kay Gürtzig     2016.07.21      KGU#207: Slight performance improvement in getElementByCoord()
  *      Kay Gürtzig     2016.10.13      Enh. #270: Hatched overlay texture in draw() if disabled
+ *      Kay Gürtzig     2016.12.12      Bugfix #308 in haveOuterRectDrawn() - must be drawn in collapsed mode
  *
  ******************************************************************************************************
  *
@@ -109,7 +110,10 @@ public class Repeat extends Element implements ILoop {
 	// START KGU#227 2016-07-30: Enh. #128
 	protected boolean haveOuterRectDrawn()
 	{
-		return false;
+		// START KGU#308 2016-12-12: Bugfix #308
+		//return false;
+		return this.isCollapsed();
+		// END KGU#308 2016-12-12
 	}
 	// END KGU#227 2016-07-30
 

--- a/src/lu/fisch/structorizer/executor/Control.java
+++ b/src/lu/fisch/structorizer/executor/Control.java
@@ -50,6 +50,8 @@ package lu.fisch.structorizer.executor;
  *      Kay Gürtzig     2016.10.07      KGU#68 (issue #15) ConcurrentHashMap replaces Object[] for variable editing
  *      Kay Gürtzig     2016.10.08      Issue #264 variable display updates caused frequent silent exceptions on rendering
  *      Kay Gürtzig     2016.11.01      Issue #81: Icon and frame size scaling ensured according to scaleFactor
+ *      Kay Gürtzig     2016.11.09      Issue #81: Scale factor no longer rounded.
+ *      Kay Gürtzig     2016.12.12      Issue #307: New error message msgForLoopManipulation
  *
  ******************************************************************************************************
  *
@@ -286,7 +288,8 @@ public class Control extends LangFrame implements PropertyChangeListener, ItemLi
         jScrollPane1.setViewportView(tblVar);
 
         // START KGU#287 2016-11-02: Issue #81 (DPI awareness workarounds)
-        double scaleFactor = Double.valueOf(Ini.getInstance().getProperty("scaleFactor","1")).intValue();
+        double scaleFactor = Double.valueOf(Ini.getInstance().getProperty("scaleFactor","1"));
+        if (scaleFactor < 1) scaleFactor = 1.0; 
         tblVar.setRowHeight((int)(tblVar.getRowHeight() * scaleFactor));
         // END KGU#2987 2016-11-02
         // START KGU#210 2016-07-25: Issue #201 - new GridBagLayout-based GUI (easier to handle)
@@ -714,6 +717,10 @@ public class Control extends LangFrame implements PropertyChangeListener, ItemLi
     public final LangTextHolder msgTitleQuestion =
     		new LangTextHolder("Question");
     // END KGU#247 2016-09-17
+    // START KGU#307 2016-12-12: Enh. #307
+    public final LangTextHolder msgForLoopManipulation =
+    		new LangTextHolder("Illegal attempt to manipulate the FOR loop variable «%»!");
+    // END KGU#307 2016-12-12
     
     // START KGU#68 2015-11-06: Register variable value editing events
     private final ConcurrentMap<String, Object> varUpdates = new ConcurrentHashMap<String, Object>();

--- a/src/lu/fisch/structorizer/executor/ExecutionStackEntry.java
+++ b/src/lu/fisch/structorizer/executor/ExecutionStackEntry.java
@@ -20,10 +20,6 @@
 
 package lu.fisch.structorizer.executor;
 
-import bsh.Interpreter;
-import lu.fisch.structorizer.elements.Root;
-import lu.fisch.utils.StringList;
-
 /******************************************************************************************************
  *
  *      Author:         Kay Gürtzig
@@ -39,6 +35,7 @@ import lu.fisch.utils.StringList;
  *      ------			----			-----------
  *      Kay Gürtzig		2015.11.13		First Issue
  *      Kay Gürtzig		2015.11.26		Extended by loopDepth (needed for the JUMP execution)
+ *      Kay Gürtzig     2016.12.12      Issue #307: Extended by forLoopVars
  *
  ******************************************************************************************************
  *
@@ -46,10 +43,17 @@ import lu.fisch.utils.StringList;
  *
  ******************************************************************************************************///
 
+import bsh.Interpreter;
+import lu.fisch.structorizer.elements.Root;
+import lu.fisch.utils.StringList;
+
 public class ExecutionStackEntry {
 	
 	public Root root;					// The caller root itself (only necessary to preserve flags?)
 	public StringList variables;		// The variable names used up to the suspending call
+	// START KGU#307 2016-12-12: Issue #307: Keep track of FOR loop variables
+	public StringList forLoopVars;		// Hierarchy of FOR loop variables within this stack frame 
+	// END KGU#307 2016-12-12
 	public Interpreter interpreter;		// The execution context (containing variable values etc.)
 	// START KGU#78 2015-11-25
 	public int loopDepth;				// The current nesting level of loops
@@ -57,7 +61,10 @@ public class ExecutionStackEntry {
 
 	// START KGU#78 2015-11-25
 	//public ExecutionStackEntry(Root _root, StringList _variables, Interpreter _interpreter)
-	public ExecutionStackEntry(Root _root, StringList _variables, Interpreter _interpreter, int _loopDepth)
+	// START KGU#307 2016-12-12: Issue #307: Keep track of FOR loop variables
+	//public ExecutionStackEntry(Root _root, StringList _variables, Interpreter _interpreter, int _loopDepth)
+	public ExecutionStackEntry(Root _root, StringList _variables, Interpreter _interpreter, int _loopDepth, StringList _forLoopVars)
+	// END KGU#307 2016-12-12
 	// END KGU#78 2015-11-25
 	{
 		_root.isCalling = true;
@@ -67,6 +74,9 @@ public class ExecutionStackEntry {
 		// START KGU#78 2015-11-25
 		this.loopDepth = _loopDepth;
 		// END KGU#78 2015-11-25
+		// START KGU#307 2016-12-12: Issue #307: Keep track of FOR loop variables
+		this.forLoopVars = _forLoopVars; 
+		// END KGU#307 2016-12-12
 	}
 
 }

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -105,6 +105,7 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.11.18/19   Issue #269: Scroll to the element associated to a selected Analyser error
  *      Kay Gürtzig     2016.11.21      Issue #269: Focus alignment improved for large elements
  *      Kay Gürtzig     2016.12.02      Enh. #300: Update notification mechanism
+ *      Kay Gürtzig     2016.12.12      Enh, #305: Infrastructure for Arranger root list
  *
  ******************************************************************************************************
  *
@@ -197,6 +198,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
     // END KGU#2 2015-11-24
 
     private JList<DetectedError> errorlist = null;
+    private JList<Root> diagramIndex = null;
 
     private Element eCopy = null;
 
@@ -233,6 +235,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
         if(_editor!=null)
         {
             errorlist=_editor.errorlist;
+            diagramIndex = _editor.diagramIndex;
             NSDControl = _editor;
         }
         create(_string);
@@ -818,7 +821,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
                                         if(NSDControl!=null) NSDControl.doButtons();
 				}*/
 			}
-			else
+			else if (e.getSource() == errorlist)
 			{
 				// an error list entry has been selected
 				if(errorlist.getSelectedIndex()!=-1)
@@ -851,6 +854,12 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 					// END KGU#200 2016-07-27
 				}
 			}
+			// START KGU#305 2016-12-12: Enh. #305
+			else if (e.getSource() == diagramIndex)
+			{
+				Arranger.scrollToDiagram(diagramIndex.getSelectedValue(), true);
+			}
+			// END KGU#305 2016-12-12
 		}
                 // edit the element
 		else if ((e.getClickCount() == 2))
@@ -884,7 +893,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 					if(NSDControl!=null) NSDControl.doButtons();
 				}
 			}
-			else
+			else if (e.getSource() == errorlist)
 			{
 				// the error list has been clicked
 				if(errorlist.getSelectedIndex()!=-1)
@@ -897,6 +906,15 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 					if(NSDControl!=null) NSDControl.doButtons();
 				}
 			}
+			// START KGU#305 2016-12-12: Enh. #305
+			else if (e.getSource() == diagramIndex)
+			{
+				Root selectedRoot = diagramIndex.getSelectedValue();
+				if (selectedRoot != null && selectedRoot != this.root) {
+					this.setRoot(selectedRoot, true);
+				}
+			}
+			// END KGU#305 2016-12-12
 		}
 	}
 
@@ -1378,7 +1396,7 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 	 *****************************************/
 	
 	/**
-	 * Stores unsaved changes (if any). If _checkChanges is true then the user may confirms or deny saving or cancel the
+	 * Stores unsaved changes (if any). If _checkChanges is true then the user may confirm or deny saving or cancel the
 	 * inducing request. 
 	 * @param _checkChanged - if true and the current root has unsaved changes then a user dialog will be popped up first
 	 * @return true if the user cancelled the save request
@@ -1389,13 +1407,13 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 		// only save if something has been changed
 		// START KGU#137 2016-01-11: Use the new method now
 		//if(root.hasChanged==true)
-		if (root.hasChanged())
+		if (!root.isEmpty() && root.hasChanged())
 		// END KGU#137 2016-01-11
 		{
 
 			if (_checkChanged==true)
 			{
-				// START KGU#49 2015-10-18: If induced by Arranger then it's less ambiguous to see the NSD name
+				// START KGU#49 2015-10-18: If induced by Arranger then it's less ambiguous seeing the NSD name
 				//res = JOptionPane.showOptionDialog(this,
 				//		   "Do you want to save the current NSD-File?",
 				String filename = root.filename;

--- a/src/lu/fisch/structorizer/gui/Diagram.java
+++ b/src/lu/fisch/structorizer/gui/Diagram.java
@@ -3817,49 +3817,54 @@ public class Diagram extends JPanel implements MouseMotionListener, MouseListene
 				}
 
 			} catch (MalformedURLException e) {
-				e.printStackTrace();
+				System.err.println("Diagram.retrievaLatestVersion: " + e.toString());
 			} catch (IOException e) {
-				e.printStackTrace();
+				System.err.println("Diagram.retrievaLatestVersion: " + e.toString());
 			}
 		}
 		return version;
 	}
 
-	private static int[] splitVersionString(String version)
-	{
-		StringList versionParts = StringList.explode(version, "\\.");
-		versionParts = StringList.explode(versionParts, "-");
-		int[] versionNumbers = new int[versionParts.count()];
-		for (int i = 0; i < versionParts.count(); i++) {
-			try {
-				versionNumbers[i] = Integer.parseInt(versionParts.get(i));
-			}
-			catch (NumberFormatException ex) {
-				versionNumbers[i] = 0;
-			}
-		}
-		return versionNumbers;
-	}
+	// START KGU#300 2016-12-06: Not actually needed
+//	private static int[] splitVersionString(String version)
+//	{
+//		StringList versionParts = StringList.explode(version, "\\.");
+//		versionParts = StringList.explode(versionParts, "-");
+//		int[] versionNumbers = new int[versionParts.count()];
+//		for (int i = 0; i < versionParts.count(); i++) {
+//			try {
+//				versionNumbers[i] = Integer.parseInt(versionParts.get(i));
+//			}
+//			catch (NumberFormatException ex) {
+//				versionNumbers[i] = 0;
+//			}
+//		}
+//		return versionNumbers;
+//	}
+	// END KGU#300 2016-12-06
 	
 	public String getLatestVersionIfNewer()
 	{
 		int cmp = 0;
 		String latestVerStr = retrieveLatestVersion();
 		if (latestVerStr != null) {
-			int[] thisVersion = splitVersionString(Element.E_VERSION);
-			int[] currVersion = splitVersionString(latestVerStr);
-			int minLen = Math.min(thisVersion.length, currVersion.length);
-			for (int i = 0; i < minLen && cmp == 0; i++) {
-				if (currVersion[i] < thisVersion[i]) {
-					cmp = -1;
-				}
-				else if (currVersion[i] > thisVersion[i]) {
-					cmp = 1;
-				}
-			}
-			if (cmp == 0 && minLen < currVersion.length) {
-				cmp = 1;
-			}
+			// START KGU#300 2016-12-06: The lexicographic comparison is quite perfect here
+//			int[] thisVersion = splitVersionString(Element.E_VERSION);
+//			int[] currVersion = splitVersionString(latestVerStr);
+//			int minLen = Math.min(thisVersion.length, currVersion.length);
+//			for (int i = 0; i < minLen && cmp == 0; i++) {
+//				if (currVersion[i] < thisVersion[i]) {
+//					cmp = -1;
+//				}
+//				else if (currVersion[i] > thisVersion[i]) {
+//					cmp = 1;
+//				}
+//			}
+//			if (cmp == 0 && minLen < currVersion.length) {
+//				cmp = 1;
+//			}
+			cmp = latestVerStr.compareTo(Element.E_VERSION);
+			// END KGU#300 2016-12-06
 		}
 		return (cmp > 0 ? latestVerStr : null);
 	}

--- a/src/lu/fisch/structorizer/gui/Mainform.java
+++ b/src/lu/fisch/structorizer/gui/Mainform.java
@@ -52,7 +52,8 @@ package lu.fisch.structorizer.gui;
  *      Kay Gürtzig     2016.10.11      Enh. #267: New method updateAnalysis() introduced
  *      Kay Gürtzig     2016.11.01      Issue #81: Scale factor from Ini also applied to fonts
  *      Kay Gürtzig     2016.11.09      Issue #81: Scale factor no longer rounded except for icons, ensured to be >= 1
- *      Kay Gürtzig     2016.12.02      Enh. #300: Notification of disabled version retrieval or new versions  
+ *      Kay Gürtzig     2016.12.02      Enh. #300: Notification of disabled version retrieval or new versions
+ *      Kay Gürtzig     2016.12.12      Enh. #305: API enhanced to support the Arranger Root index view
  *
  ******************************************************************************************************
  *
@@ -74,7 +75,9 @@ package lu.fisch.structorizer.gui;
  ******************************************************************************************************///
 
 import java.io.*;
+import java.util.Collections;
 import java.util.Set;
+import java.util.Vector;
 import java.awt.*;
 import java.awt.event.*;
 
@@ -722,5 +725,22 @@ public class Mainform  extends LangFrame implements NSDController
     	}
     }
     // END KGU#300 2016-12-02
+    
+    // START KGU#305 2016-12-12: Enh. #305 - Pass diagram list of Arranger to editor
+    public void updateArrangerIndex()
+    {
+    	Vector<Root> diagrams = new Vector<Root>();
+    	if (Arranger.hasInstance()) {
+    		diagrams.addAll(Arranger.getInstance().getAllRoots());
+    		Collections.sort(diagrams, Root.SIGNATURE_ORDER);
+    	}
+    	this.editor.updateArrangerIndex(diagrams);
+    }
+    
+    public boolean isStandalone()
+    {
+    	return this.isStandalone;
+    }
+    // END KGU#305 2016-12-12
 	
 }

--- a/src/lu/fisch/structorizer/gui/RootListCellRenderer.java
+++ b/src/lu/fisch/structorizer/gui/RootListCellRenderer.java
@@ -1,0 +1,93 @@
+/*
+    Structorizer
+    A little tool which you can use to create Nassi-Schneiderman Diagrams (NSD)
+
+    Copyright (C) 2009  Bob Fisch
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or any
+    later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package lu.fisch.structorizer.gui;
+
+import java.awt.Color;
+
+/*******************************************************************************************************
+ *
+ *      Author:         Kay Gürtzig
+ *
+ *      Description:    A special class rendering the cells of a Root list.
+ *
+ ******************************************************************************************************
+ *
+ *      Revision List
+ *
+ *      Author          Date            Description
+ *      ------          ----            -----------
+ *      Kay Gürtzig     12.12.2016      First Issue
+ *
+ ******************************************************************************************************
+ *
+ *      Comment:
+ *      Introduced for a first implementation of enhancement #305
+ *
+ ******************************************************************************************************///
+
+import java.awt.Component;
+
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.ListCellRenderer;
+import javax.swing.UIManager;
+
+import lu.fisch.structorizer.elements.Root;
+
+/**
+ * @author Kay Gürtzig
+ *
+ */
+
+@SuppressWarnings("serial")
+class RootListCellRenderer extends JLabel implements ListCellRenderer<Root>{
+    private final static ImageIcon mainIcon = IconLoader.ico022;
+    private final static ImageIcon subIcon = IconLoader.ico021;
+    private final static Color selectedBackgroundNimbus = new Color(57,105,138);
+
+	@Override
+	public Component getListCellRendererComponent(JList<? extends Root> list, Root root, int index, boolean isSelected,
+			boolean cellHasFocus) {
+        String s = root.getSignatureString(true);
+        setText(s);
+        setIcon((root.isProgram) ? mainIcon : subIcon);
+        if (isSelected) {
+    		if (UIManager.getLookAndFeel().getName().equals("Nimbus"))
+    		{
+    			// Again, a specific handling for Nimbus was necessary in order to show any difference at all.
+    			setBackground(selectedBackgroundNimbus);
+    			setForeground(Color.WHITE);
+    		}
+    		else {
+                setBackground(list.getSelectionBackground()/*Color.BLUE*/);
+                setForeground(list.getSelectionForeground()/*Color.WHITE*/);    			
+    		}
+        } else {
+            setBackground(list.getBackground());
+            setForeground(list.getForeground());
+        }
+        setEnabled(list.isEnabled());
+        setFont(list.getFont());
+        setOpaque(true);
+        return this;
+	}
+	
+}

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -5,7 +5,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-09 (2016.12.02)
+Current development version: 3.25-10 (2016.12.07)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -77,6 +77,7 @@ Current development version: 3.25-09 (2016.12.02)
 - 09: Bugfix #301: Parentheses handling around conditions on code export fixed <2>
 - 09: Enh. #302: New Turtleizer procedures setPenColor, setBackground [newboerg]2
 - 09: Bugfix #302: Effects of previous penUp and hideTurtle now undone on new start <2>
+- 10: Issue #304: Menu mnemonic translation damaged the menu with legacy JavaRE <2> 
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -5,7 +5,7 @@
 <Foo>   -->     idea AND coding done by Foo
 <2>     -->     idea and coding done by Kay Gürtzig
 
-Current development version: 3.25-10 (2016.12.07)
+Current development version: 3.25-10 (2016.12.13)
 - 01: Issue #213: FOR transmutation now inserts WHILE parser preferences <2>
 - 01: Issue #213: Selected state of FOR transmutation result now visible <2>
 - 01: Bugfix #241: Translation bugs for element editor mended <2>
@@ -65,7 +65,7 @@ Current development version: 3.25-10 (2016.12.07)
 - 08: Issue #231: Traditional reserved BASIC words added to name collision checks <2>
 - 08: Issue #269: Vertical scrolling alignment for large elements improved <2>
 - 08: Issue #284: Text field fonts in element editor now interactively resizable [ebial]2
-- 08: Bugfix #293: Input and output boxes no longer popd up at odd places on screen <2>
+- 08: Bugfix #293: Input and output boxes no longer pop up at odd places on screen <2>
 - 08: Font resizing accelerators unified among different dialogs and menus <2>
 - 08: Label defect in FOR loop editor (class InputBoxFor) mended <2>
 - 08: Bugfix #294: Test coverage wasn't shown for CASE elements w/o default branch <2>
@@ -77,7 +77,11 @@ Current development version: 3.25-10 (2016.12.07)
 - 09: Bugfix #301: Parentheses handling around conditions on code export fixed <2>
 - 09: Enh. #302: New Turtleizer procedures setPenColor, setBackground [newboerg]2
 - 09: Bugfix #302: Effects of previous penUp and hideTurtle now undone on new start <2>
-- 10: Issue #304: Menu mnemonic translation damaged the menu with legacy JavaRE <2> 
+- 10: Issue #304: Menu mnemonic localization killed the menu on legacy JavaRE <2>
+- 10: Issue #305: Arranger diagram index added to the Structorizer GUI [newboerg]2
+- 10: Issue #306: Structorizer may load several diagrams on command line start <2>
+- 10: Issue #307: Executor error on manipulation of FOR loop variables [newboerg]2
+- 10: Bugfix #308: Collapsed REPEAT loops weren't properly drawn<2>
 
 Version: 3.25 (2016.09.09)
 - 01: Enh. #77: Test coverage mode highlights all code paths passed [elemhsb]2
@@ -657,7 +661,7 @@ Version 1.26 [12/06/2007]
 - Bug detected in the cut method [Andreas Jenet]
 - MDI: Eliminated memory bug in MDI application [FISRO]
 - MDI: First working MDI application called "Projectorizer"
-- MDI: Projet save and load works. Filetype = combined NSD
+- MDI: Project save and load works. Filetype = combined NSD
   files in XML format. Extension = nsdp [FISRO]
 - MDI: Add diagram to project [FISRO]
 - MDI: Menu integration [FISRO]

--- a/src/lu/fisch/structorizer/locales/Locales.java
+++ b/src/lu/fisch/structorizer/locales/Locales.java
@@ -645,15 +645,13 @@ public class Locales {
                                 } // START KGU#184 2016-04-24: Enh. #173 - new mnemonic support (only works from Java 1.7 on)
                                 else if (piece2.equals("mnemonic")) {
                                     Method method = fieldClass.getMethod("setMnemonic", new Class[]{int.class});
-                                    // START KGU 2016-12-07: Issue #304 We must check the availability of a Java 1.7 method first.
+                                    // START KGU 2016-12-07: Issue #304 We must check the availability of a Java 1.7 method.
                                     try {
-                                        KeyEvent.class.getDeclaredMethod("getExtendedKeyCodeForChar", new Class[]{int.class});
-                                        // If we passed the reflection test above then we may go ahead... 
                                         int keyCode = KeyEvent.getExtendedKeyCodeForChar(parts.get(1).toLowerCase().charAt(0));
                                         if (keyCode != KeyEvent.VK_UNDEFINED && target != null) {
                                             method.invoke(target, new Object[]{Integer.valueOf(keyCode)});
                                         }
-                                    } catch (NoSuchMethodException ex) {
+                                    } catch (NoSuchMethodError ex) {
                                     	System.out.println("Locales: Mnemonic localization failed due to legacy JavaRE (at least 1.7 required).");
                                     }
                                     // END KGU 2016-12-07

--- a/src/lu/fisch/structorizer/locales/Locales.java
+++ b/src/lu/fisch/structorizer/locales/Locales.java
@@ -40,6 +40,7 @@ package lu.fisch.structorizer.locales;
  *      Kay Gürtzig     2016.09.13  Bugfix #241 in checkConditions() (KGU#246)
  *      Kay Gürtzig     2016.09.22  Issue #248: Workaround for Linux systems with Java 1.7
  *      Kay Gürtzig     2016.09.28  KGU#263: Substrings "\n" in the text part now generally replaced by newline
+ *      Kay Gürtzig     2016.12.07  Issue #304: Check for feasibility of mnemonic replacement via Reflection
  *
  ******************************************************************************************************
  *
@@ -641,14 +642,22 @@ public class Locales {
                                     Method method = fieldClass.getMethod("setHeaderTitle", new Class[]{int.class, String.class});
                                     if(target != null)
                                         method.invoke(target, new Object[]{Integer.valueOf(pieces.get(3)), parts.get(1)});
-                                } // START KGU#183 2016-04-24: Enh. #173 - new support
+                                } // START KGU#184 2016-04-24: Enh. #173 - new mnemonic support (only works from Java 1.7 on)
                                 else if (piece2.equals("mnemonic")) {
                                     Method method = fieldClass.getMethod("setMnemonic", new Class[]{int.class});
-                                    int keyCode = KeyEvent.getExtendedKeyCodeForChar(parts.get(1).toLowerCase().charAt(0));
-                                    if (keyCode != KeyEvent.VK_UNDEFINED && target != null) {
-                                        method.invoke(target, new Object[]{Integer.valueOf(keyCode)});
+                                    // START KGU 2016-12-07: Issue #304 We must check the availability of a Java 1.7 method first.
+                                    try {
+                                        KeyEvent.class.getDeclaredMethod("getExtendedKeyCodeForChar", new Class[]{int.class});
+                                        // If we passed the reflection test above then we may go ahead... 
+                                        int keyCode = KeyEvent.getExtendedKeyCodeForChar(parts.get(1).toLowerCase().charAt(0));
+                                        if (keyCode != KeyEvent.VK_UNDEFINED && target != null) {
+                                            method.invoke(target, new Object[]{Integer.valueOf(keyCode)});
+                                        }
+                                    } catch (NoSuchMethodException ex) {
+                                    	System.out.println("Locales: Mnemonic localization failed due to legacy JavaRE (at least 1.7 required).");
                                     }
-                                } // END KGU#183 2016-04-24
+                                    // END KGU 2016-12-07
+                                } // END KGU#184 2016-04-24
                                 // START KGU#156 2016-03-13: Enh. #124 - intended for JComboBoxes
                                 else if (piece2.equals("item")) {
                                     // The JCombobox is supposed to be equipped with enum objects providing a setText() method

--- a/src/lu/fisch/structorizer/locales/de.txt
+++ b/src/lu/fisch/structorizer/locales/de.txt
@@ -86,6 +86,7 @@
  *      Kay Gürtzig         2016.11.08  Enh. #270: Editor.btnDisable.tooltip added
  *      Kay Gürtzig         2016.11.10  Enh. #286: AnalyserPreferences tabs
  *      Kay Gürtzig         2016.12.02  Enh. #300: New messages for update retrieval
+ *      Kay Gürtzig         2016.12.02  Issue #307: New executor error message
  *
  ******************************************************************************************************
  *
@@ -770,6 +771,7 @@ Control.msgExitCode.text=Programm abgebrochen mit Code %1!
 Control.msgIllegalJump.text=Unzulässiger Inhalt einer Aussprung-Anweisung: <%1>!
 Control.msgTooManyLevels.text=Zu viele Ebenen zum Verlassen gefordert (tatsächliche Tiefe: %1 / angegeben: %2)!
 Control.msgJumpOutParallel.text=Unzulässiger Aussprung aus Parallelzweig:%Thread beendet!
+Control.msgForLoopManipulation.text=Unzulässige Manipulation der Zählschleifenvariablen «%»!
 Control.tblVar.header.0=Variablenname
 Control.tblVar.header.1=Inhalt
 

--- a/src/lu/fisch/structorizer/locales/en.txt
+++ b/src/lu/fisch/structorizer/locales/en.txt
@@ -83,6 +83,7 @@
  *      Kay Gürtzig     2016.11.08      Enh. #270: Editor.btnDisable.tooltip added
  *      Kay Gürtzig     2016.11.10      Enh. #286: AnalyserPreferences tabs
  *      Kay Gürtzig     2016.12.02      Enh. #300: New messages for update retrieval
+ *      Kay Gürtzig     2016.12.02      Issue #307: New executor error message
  *
  ******************************************************************************************************
  *
@@ -772,6 +773,7 @@ Control.msgExitCode.text=Program exited with code %1!
 Control.msgIllegalJump.text=Illegal content of a Jump (i.e. exit) instruction: <%1>!
 Control.msgTooManyLevels.text=Too many levels to leave (actual depth: %1 / specified: %2)!
 Control.msgJumpOutParallel.text=Illegal attempt to jump out of a parallel thread:%Thread killed!
+Control.msgForLoopManipulation.text=Illegal attempt to manipulate the FOR loop variable «%»!
 Control.tblVar.header.0=Variable Name
 Control.tblVar.header.1=Content
 

--- a/src/lu/fisch/structorizer/locales/es.txt
+++ b/src/lu/fisch/structorizer/locales/es.txt
@@ -87,6 +87,7 @@
  *      Kay Gürtzig     2016.11.08  Enh. #270: Editor.btnDisable.tooltip added
  *      Kay Gürtzig     2016.11.10  Enh. #286: AnalyserPreferences tabs
  *      Kay Gürtzig     2016.12.02  Enh. #300: New messages for update retrieval
+ *      Kay Gürtzig     2016.12.02  Issue #307: New executor error message
  *
  ******************************************************************************************************
  *
@@ -771,6 +772,7 @@ Control.msgExitCode.text=¡Programa abortado con código %1!
 Control.msgIllegalJump.text=¡Contenido ilegal del SALTO (instruction para salir): <%1>!
 Control.msgTooManyLevels.text=¡Demasiados niveles para salir (niveles reales: %1 / especificados: %2)!
 Control.msgJumpOutParallel.text=Tentativa ilegal de saltar afuera de un brazo paralelo:%¡Brazo terminado!
+Control.msgForLoopManipulation.text=¡Manipulación ilegal de la variable «%» de un bucle PARA!
 Control.tblVar.header.0=Nombre de Variable
 Control.tblVar.header.1=Contenido
 


### PR DESCRIPTION
Issue #304: Menu mnemonic localization had killed the menu on legacy JavaRE
Issue #305: Arranger diagram index added to the Structorizer GUI
Issue #306: Structorizer may load several diagrams on command line start
Issue #307: Executor error on manipulation of FOR loop variables
Bugfix #308: Collapsed REPEAT loops weren't properly drawn

@fesch 
User Guide has already been updated this time.
What about this idea: Could we (i.e. you ;-) automatically place the current (latest) version number below the Structorizer symbol on the title page of the extracted PDF version?