### PR TITLE
Defective key in en.txt locale mended for relaunch 3.26-04

### DIFF
--- a/src/lu/fisch/structorizer/locales/en.txt
+++ b/src/lu/fisch/structorizer/locales/en.txt
@@ -298,7 +298,7 @@ Menu.msgNewerVersionAvail.text=Newer version % available for download.
 Menu.msgUpdateInfoHint.text=If you want to get notified of available new versions\nyou may enable update retrieval from Structorizer homepage\nvia menu item "%1" > "%2".
 Menu.lblOk.text=OK
 Menu.lblSuppressUpdateHint.text=Don't show this window again
-Menu.lblHint.txt=Hint
+Menu.lblHint.text=Hint
 
 // Error messages for analyser
 // warning_1 must be consistent with Menu.menuDiagram.text and Menu.menuDiagramSwitchComments.text!


### PR DESCRIPTION
 The key fault had prevented Translator from opening, already in 3.26-03 or earlier.