### PR TITLE
added quotation mark for java -jar call

### DIFF
--- a/structorizer.sh
+++ b/structorizer.sh
@@ -53,4 +53,4 @@ fi
 
 # actual start
 #echo "Your Java Version is $VERSION, all fine."
-java -jar $DIR/Structorizer.app/Contents/Java/Structorizer.jar "$@"
+java -jar "$DIR/Structorizer.app/Contents/Java/Structorizer.jar" "$@"


### PR DESCRIPTION
When downloading Sturctorizer and putting it in an directory with an whitespace inside ('/home/user/directory with whitespace/") the call `java -jar $DIR/Structorizer.app/Contents/Java/Structorizer.jar "$@"` fails with  `Error: Unable to access jarfile /home/user/directory`. 

Adding `"` fixes this issue. 
