### PR TITLE
update copyright year

### DIFF
--- a/LIC-NOTE-structorizer
+++ b/LIC-NOTE-structorizer
@@ -5,7 +5,7 @@ Structorizer licenses file
     A free, open-source editor for Nassi-Shneiderman Diagrams (NSD) with
     numerous code import, code export, execution, and analysis capabilities.
 
-    Copyright (C) 2009 Bob Fisch
+    Copyright (C) 2020 Bob Fisch
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The common way is to either specify the last year in the license note or all years with substantial changes. This uses the first.

Just recognized the old year when using the current installer...