### PR TITLE
'var' declarations replaced (for syntactical compatibility with Java 8)

### DIFF
--- a/src/lu/fisch/structorizer/elements/Instruction.java
+++ b/src/lu/fisch/structorizer/elements/Instruction.java
@@ -1010,7 +1010,7 @@ public class Instruction extends Element {
 	 */
 	public static StringList getDeclaredVariables(StringList _tokens)
 	{
-		var declVars = new StringList();
+		StringList declVars = new StringList();
 		if (_tokens.indexOf("var", false) == 0 || _tokens.indexOf("dim", false) == 0) {
 			int posColon = _tokens.indexOf(":", 2);
 			if (posColon > 1 || (posColon = _tokens.indexOf("as", false)) > 1) {

--- a/src/lu/fisch/structorizer/elements/Root.java
+++ b/src/lu/fisch/structorizer/elements/Root.java
@@ -5887,8 +5887,8 @@ public class Root extends Element {
 			}
 			else {
 				// Let's check the index lists now
-				var defective = new StringList();
-				var badSizes = new StringList();
+				StringList defective = new StringList();
+				StringList badSizes = new StringList();
 				unifyOperators(tokens, true);
 				tokens.remove(tokens.indexOf("<-"), tokens.count());
 				tokens = Element.coagulateSubexpressions(tokens);

--- a/src/lu/fisch/structorizer/gui/changelog.txt
+++ b/src/lu/fisch/structorizer/gui/changelog.txt
@@ -23,7 +23,7 @@ Known issues:
 - ARM export is still experimental and relies on a specific and very restricted
   syntax for the element contents in order to produce meaningful results.
 
-Current development version 3.32-13 (2023-10-29)
+Current development version 3.32-13 (2023-10-31)
 - 01: Bugfix #987: Duplicate subroutine comment export by Pascal generator <2>
 - 01: Bugfix #988: Syntax error in Structorizer.bat and Arranger.bat fixed <2>
 - 01: Bugfix #989: Expressions in EXIT elements (e.g. return) were forgotten


### PR DESCRIPTION
I hope I found them all.
Please don't forget to merge Upla as well before delivery...