### PR TITLE
Added freedesktop integration

### DIFF
--- a/freedesktop/applications/structorizer.desktop
+++ b/freedesktop/applications/structorizer.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Version=1.4
+Name=Structorizer
+GenericName=Diagram creator
+Comment=Create Nassi-Shneiderman diagrams (NSD)
+Icon=structorizer
+Exec=structorizer
+Terminal=false
+MimeType=application/nsd
+Categories=Development;Graphics;VectorGraphics;RasterGraphics;ComputerScience
+Keywords=nsd;diagrams

--- a/freedesktop/mime/packages/structorizer.xml
+++ b/freedesktop/mime/packages/structorizer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/nsd">
+    <sub-class-of type="application/xml"/>
+    <comment xml:lang="en">Nassi-Shneiderman diagram</comment>
+    <comment xml:lang="de">Nassi-Shneiderman-Diagramm</comment>
+    <glob pattern="*.nsd"/>
+  </mime-type>
+</mime-info>


### PR DESCRIPTION
## mimetype file

I added a file specifying the application/nsd mimetype so that a structorizer.desktop file can specify that the program supports opening files of this mimetype.

I am not sure if the location of the file is appropriate for this project.

If you merge this, please take care of copying this file into packaged versions of structorizer in the appropriate build scripts, i don't know my way around those.

Unfortunately, I failed at matching the mimetype based of the XML namespace so I did it by matching on the .nsd file extension which is not ideal… (relevant spec: https://specifications.freedesktop.org/shared-mime-info-spec/latest/ar01s02.html)

Here's how i tried to match via the XML namespace:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
  <mime-type type="application/nsd">
    <sub-class-of type="application/xml"/>
    <comment xml:lang="en">Nassi-Shneiderman diagram</comment>
    <comment xml:lang="de">Nassi-Shneiderman-Diagramm</comment>
    <root-XML namespaceURI="https://structorizer.fisch.lu" localName="root"/>
  </mime-type>
</mime-info>
```

## desktop entry file

a desktop entry was also added, which specifies that the program supports the defined mimetype.

## motivation

these files allow for easier packaging of this program and facilitate the use of *the same* desktop entry and mimetype files across various distributions.