### PR TITLE
Added new --non-reparenting argument to the structorizer.sh script

### DIFF
--- a/structorizer.sh
+++ b/structorizer.sh
@@ -53,6 +53,21 @@ then
   exit 1
 fi
 
+# Optional Script Arguments
+while [ "$#" -gt 0 ]; do
+  arg=$1
+  shift
+  case "$arg" in
+    --non-reparenting|-nrp)
+      # Fix for some Linux Window Managers, e.g. sway
+      export _JAVA_AWT_WM_NONREPARENTING=1
+      ;;
+     *)
+      set -- "$@" "$arg"
+      ;;
+  esac
+done
+
 # actual start
 #echo "Your Java version is $VERSION, all fine."
 java -jar "$DIR/Structorizer.app/Contents/Java/Structorizer.jar" "$@"


### PR DESCRIPTION
On Linux, Structorizer may fail to start under non-reparenting window managers (e.g. sway).

This PR updates `structorizer.sh` to optionally set the required environment variable when launching:
- new flag: `--non-reparenting` (alias: `-nrp`).
- when present, the script exports the env var before starting Structorizer.
- all other arguments are still forwarded unchanged as before.

Please let me know if you’d prefer different flag naming or placement.